### PR TITLE
Cognito delete user

### DIFF
--- a/LBHFSSPortalAPI/Startup.cs
+++ b/LBHFSSPortalAPI/Startup.cs
@@ -125,7 +125,8 @@ namespace LBHFSSPortalAPI
             {
                 AccessKeyId = Environment.GetEnvironmentVariable("COGNITO_USER"),
                 SecretAccessKey = Environment.GetEnvironmentVariable("COGNITO_KEY"),
-                ClientId = Environment.GetEnvironmentVariable("CLIENT_ID")
+                ClientId = Environment.GetEnvironmentVariable("CLIENT_ID"),
+                UserPoolId = Environment.GetEnvironmentVariable("POOL_ID")
             };
             services.AddTransient<IAuthenticateGateway>(x => new AuthenticateGateway(connInfo));
             services.AddScoped<IUsersGateway, UsersGateway>();

--- a/LBHFSSPortalAPI/V1/Controllers/UsersController.cs
+++ b/LBHFSSPortalAPI/V1/Controllers/UsersController.cs
@@ -65,16 +65,16 @@ namespace LBHFSSPortalAPI.V1.Controllers
             return Created("Created", response);
         }
 
-        [Route("users")]
+        [Route("users/{userId}")]
         [HttpPatch]
         [ProducesResponseType(typeof(UserResponse), StatusCodes.Status200OK)]
-        public IActionResult UpdateUser([FromQuery] int currentUserId, [FromBody] UserUpdateRequest userUpdateRequest)
+        public IActionResult UpdateUser([FromRoute] int userId, [FromBody] UserUpdateRequest userUpdateRequest)
         {
             UserResponse response;
 
             try
             {
-                response = _updateUserRequestUseCase.Execute(currentUserId, userUpdateRequest);
+                response = _updateUserRequestUseCase.Execute(userId, userUpdateRequest);
             }
             catch (UseCaseException e)
             {
@@ -90,10 +90,10 @@ namespace LBHFSSPortalAPI.V1.Controllers
             return Ok(response);
         }
 
-        [Route("users")]
+        [Route("users/{userId}")]
         [HttpDelete]
         [ProducesResponseType(typeof(UserResponse), StatusCodes.Status200OK)]
-        public IActionResult DeleteUser([FromQuery] int userId)
+        public IActionResult DeleteUser([FromRoute] int userId)
         {
             try
             {

--- a/LBHFSSPortalAPI/V1/Gateways/AuthenticateGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/AuthenticateGateway.cs
@@ -207,9 +207,30 @@ namespace LBHFSSPortalAPI.V1.Gateways
             return authResult;
         }
 
-        public bool DeleteUser(string subId)
+        public bool DeleteUser(string email)
         {
-            return true;
+            AdminDeleteUserRequest adminDeleteUserRequest = new AdminDeleteUserRequest
+            {
+                Username = email,
+                UserPoolId = _connectionInfo.UserPoolId
+            };
+            try
+            {
+                var response = _provider.AdminDeleteUserAsync(adminDeleteUserRequest).Result;
+                if (response.HttpStatusCode == HttpStatusCode.OK)
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                throw;
+            }
         }
     }
 }

--- a/LBHFSSPortalAPI/V1/UseCase/DeleteUserRequestUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/DeleteUserRequestUseCase.cs
@@ -24,14 +24,13 @@ namespace LBHFSSPortalAPI.V1.UseCase
 
             var user = _usersGateway.GetUser(userId);
 
-            if (_authenticateGateway.DeleteUser(user.SubId))
+            if (_authenticateGateway.DeleteUser(user.Email))
             {
                 user.Status = UserStatus.Deleted;
                 _sessionsGateway.RemoveSessions(user.Id);
                 _usersGateway.UpdateUser(user);
                 success = true;
             }
-
             return success;
         }
     }

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,5 +1,5 @@
 CREATE TABLE users (
-    "id" int4 PRIMARY KEY,
+    "id" serial PRIMARY KEY,
     "sub_id" varchar,
     "email" varchar,
     "name" varchar,


### PR DESCRIPTION
Added the method to delete a user from AWS Cognito from the authentication gateway.  

- This is to ensure that when a user is removed from the database, the associated record is removed from Cognito and prevent unauthorized access.