### PR TITLE
Implemented user <-> roles association

### DIFF
--- a/LBHFSSPortalAPI.Tests/V1/UseCase/GetAllUsersUseCaseTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/UseCase/GetAllUsersUseCaseTests.cs
@@ -31,6 +31,7 @@ namespace LBHFSSPortalAPI.Tests.V1.UseCase
             var stubbedUsers = _fixture
                     .Build<UserDomain>()
                     .Without(u => u.Organizations)
+                    .Without(u => u.UserRoles)
                     .CreateMany();
 
             var userQueryParam = new UserQueryParam()

--- a/LBHFSSPortalAPI/V1/Boundary/Requests/AdminCreateUserRequest.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Requests/AdminCreateUserRequest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace LBHFSSPortalAPI.V1.Boundary.Requests
@@ -8,10 +9,10 @@ namespace LBHFSSPortalAPI.V1.Boundary.Requests
         public string Name { get; set; }
         public string Email { get; set; }
         public string Status { get; set; }
-        public string Roles { get; set; }
+        public List<string> Roles { get; set; }
 
         [JsonPropertyName("created_at")]
-        public DateTime CreatedAt { get; set; }
+        public DateTime? CreatedAt { get; set; }
 
         [JsonPropertyName("organisation_id")]
         public int? OrganisationId { get; set; }

--- a/LBHFSSPortalAPI/V1/Boundary/Requests/UserConfirmRequest.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Requests/UserConfirmRequest.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Mvc;
 
 namespace LBHFSSPortalAPI.V1.Boundary.Requests
 {

--- a/LBHFSSPortalAPI/V1/Boundary/Requests/UserUpdateRequest.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Requests/UserUpdateRequest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace LBHFSSPortalAPI.V1.Boundary.Requests
@@ -7,7 +8,7 @@ namespace LBHFSSPortalAPI.V1.Boundary.Requests
     {
         public string Name { get; set; }
         public string Status { get; set; }
-        public string Roles { get; set; }
+        public List<string> Roles { get; set; }
         public string Password { get; set; }
 
         [JsonPropertyName("created_at")]

--- a/LBHFSSPortalAPI/V1/Boundary/Response/UserResponse.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Response/UserResponse.cs
@@ -27,6 +27,8 @@ namespace LBHFSSPortalAPI.V1.Boundary.Response
         [JsonPropertyName("created_at")]
         public DateTime? CreatedAt { get; set; }
 
+        public List<string> Roles { get; set; }
+
         [JsonPropertyName("organisation")]
         public OrganisationResponse Organisation { get; set; }
     }

--- a/LBHFSSPortalAPI/V1/Domain/RoleDomain.cs
+++ b/LBHFSSPortalAPI/V1/Domain/RoleDomain.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace LBHFSSPortalAPI.V1.Domain
+{
+    public class RoleDomain
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public DateTime? CreatedAt { get; set; }
+    }
+}

--- a/LBHFSSPortalAPI/V1/Domain/RoleDomain.cs
+++ b/LBHFSSPortalAPI/V1/Domain/RoleDomain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace LBHFSSPortalAPI.V1.Domain
 {

--- a/LBHFSSPortalAPI/V1/Domain/UserDomain.cs
+++ b/LBHFSSPortalAPI/V1/Domain/UserDomain.cs
@@ -12,6 +12,8 @@ namespace LBHFSSPortalAPI.V1.Domain
         public DateTime? CreatedAt { get; set; }
         public string SubId { get; set; }
 
-        public IEnumerable<OrganizationDomain> Organizations { get; set; }
+        public List<UserRoleDomain> UserRoles { get; set; }
+
+        public List<OrganizationDomain> Organizations { get; set; }
     }
 }

--- a/LBHFSSPortalAPI/V1/Domain/UserRoleDomain.cs
+++ b/LBHFSSPortalAPI/V1/Domain/UserRoleDomain.cs
@@ -1,15 +1,15 @@
-using System;
+﻿using System;
 
-namespace LBHFSSPortalAPI.V1.Infrastructure
+namespace LBHFSSPortalAPI.V1.Domain
 {
-    public class UserRole
+    public class UserRoleDomain
     {
         public int Id { get; set; }
         public int? RoleId { get; set; }
         public DateTime? CreatedAt { get; set; }
         public int? UserId { get; set; }
 
-        public virtual Role Role { get; set; }
-        public virtual User User { get; set; }
+        public RoleDomain Role { get; set; }
+        public UserDomain User { get; set; }
     }
 }

--- a/LBHFSSPortalAPI/V1/Domain/UserRoleDomain.cs
+++ b/LBHFSSPortalAPI/V1/Domain/UserRoleDomain.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace LBHFSSPortalAPI.V1.Domain
 {

--- a/LBHFSSPortalAPI/V1/Factories/MappingHelper.cs
+++ b/LBHFSSPortalAPI/V1/Factories/MappingHelper.cs
@@ -25,6 +25,8 @@ namespace LBHFSSPortalAPI.V1.Factories
                 cfg.CreateMap<ServiceLocation, ServiceLocationDomain>();
                 cfg.CreateMap<ServiceTaxonomy, ServiceTaxonomyDomain>();
                 cfg.CreateMap<User, UserDomain>();
+                cfg.CreateMap<UserRole, UserRoleDomain>();
+                cfg.CreateMap<Role, RoleDomain>();
             });
 
             mapperConfig.AssertConfigurationIsValid();

--- a/LBHFSSPortalAPI/V1/Factories/ResponseFactory.cs
+++ b/LBHFSSPortalAPI/V1/Factories/ResponseFactory.cs
@@ -29,7 +29,11 @@ namespace LBHFSSPortalAPI.V1.Factories
                 Status = domain.Status,
                 CreatedAt = domain.CreatedAt,
                 SubId = domain.SubId,
-                Organisation = domain.Organizations?.FirstOrDefault()?.ToResponse()
+                Organisation = domain.Organizations?.FirstOrDefault()?.ToResponse(),
+                Roles = domain.UserRoles?
+                    .Select(ur => ur.Role)
+                    .Select(r => r.Name)
+                    .ToList()
             };
 
             return response;

--- a/LBHFSSPortalAPI/V1/Gateways/Interfaces/IUsersGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/Interfaces/IUsersGateway.cs
@@ -7,16 +7,17 @@ namespace LBHFSSPortalAPI.V1.Gateways.Interfaces
 {
     public interface IUsersGateway
     {
-        UserDomain GetUser(string emailAddress, string status);
+        UserDomain GetUserByEmail(string emailAddress, string status);
         Task<List<UserDomain>> GetAllUsers(UserQueryParam userQueryParam);
         UserDomain AddUser(UserDomain user);
         UserDomain AddUser(AdminCreateUserRequest createRequestData, string subId);
         void UpdateUser(UserDomain user);
         UserDomain GetUserBySubId(string subId);
-        UserDomain GetUser(int userId);
-        Task<UserDomain> GetUserAsync(int userId);
+        UserDomain GetUserById(int userId);
+        Task<UserDomain> GetUserByIdAsync(int userId);
         OrganizationDomain GetAssociatedOrganisation(int userId);
         OrganizationDomain AssociateUserWithOrganisation(int userId, int organisationId);
         void RemoveUserOrganisationAssociation(int userId);
+        List<string> GetUserRoleList(int userId);
     }
 }

--- a/LBHFSSPortalAPI/V1/Infrastructure/DatabaseContext.cs
+++ b/LBHFSSPortalAPI/V1/Infrastructure/DatabaseContext.cs
@@ -470,22 +470,23 @@ namespace LBHFSSPortalAPI.V1.Infrastructure
 
                 entity.Property(e => e.Id)
                     .HasColumnName("id")
-                    .ValueGeneratedOnAdd()
                     .UseIdentityAlwaysColumn();
 
                 entity.Property(e => e.CreatedAt).HasColumnName("created_at");
 
                 entity.Property(e => e.RoleId).HasColumnName("role_id");
 
-                entity.HasOne(d => d.IdNavigation)
-                    .WithOne(p => p.UserRoles)
-                    .HasForeignKey<UserRole>(d => d.Id)
-                    .HasConstraintName("user_roles_id_fkey");
+                entity.Property(e => e.UserId).HasColumnName("user_id");
 
                 entity.HasOne(d => d.Role)
                     .WithMany(p => p.UserRoles)
                     .HasForeignKey(d => d.RoleId)
                     .HasConstraintName("user_roles_role_id_fkey");
+
+                entity.HasOne(d => d.User)
+                    .WithMany(p => p.UserRoles)
+                    .HasForeignKey(d => d.UserId)
+                    .HasConstraintName("user_roles_user_id_fkey");
             });
 
             modelBuilder.Entity<User>(entity =>

--- a/LBHFSSPortalAPI/V1/Infrastructure/User.cs
+++ b/LBHFSSPortalAPI/V1/Infrastructure/User.cs
@@ -10,6 +10,7 @@ namespace LBHFSSPortalAPI.V1.Infrastructure
             Organizations = new HashSet<Organization>();
             Sessions = new HashSet<Session>();
             UserOrganizations = new HashSet<UserOrganization>();
+            UserRoles = new HashSet<UserRole>();
         }
 
         public int Id { get; set; }
@@ -19,9 +20,9 @@ namespace LBHFSSPortalAPI.V1.Infrastructure
         public DateTime? CreatedAt { get; set; }
         public string Status { get; set; }
 
-        public virtual UserRole UserRoles { get; set; }
         public virtual ICollection<Organization> Organizations { get; set; }
         public virtual ICollection<Session> Sessions { get; set; }
         public virtual ICollection<UserOrganization> UserOrganizations { get; set; }
+        public virtual ICollection<UserRole> UserRoles { get; set; }
     }
 }

--- a/LBHFSSPortalAPI/V1/UseCase/AuthenticateUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/AuthenticateUseCase.cs
@@ -37,7 +37,7 @@ namespace LBHFSSPortalAPI.V1.UseCase
                 throw new UseCaseException() { UserErrorMessage = "Could not login as the password was invalid" };
 
             var loginResult = _authenticateGateway.LoginUser(loginParams);
-            var user = _usersGateway.GetUser(loginParams.Email, UserStatus.Active);
+            var user = _usersGateway.GetUserByEmail(loginParams.Email, UserStatus.Active);
             var loginResponse = CreateLoginSession(loginParams, user);
 
             return loginResponse;

--- a/LBHFSSPortalAPI/V1/UseCase/ConfirmUserUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/ConfirmUserUseCase.cs
@@ -30,11 +30,11 @@ namespace LBHFSSPortalAPI.V1.UseCase
 
             if (_authenticateGateway.ConfirmSignup(confirmRequest))
             {
-                var user = _usersGateway.GetUser(confirmRequest.Email, UserStatus.Invited);
+                var user = _usersGateway.GetUserByEmail(confirmRequest.Email, UserStatus.Invited);
 
                 if (user == null)
                 {
-                    user = _usersGateway.GetUser(confirmRequest.Email, UserStatus.Unverified);
+                    user = _usersGateway.GetUserByEmail(confirmRequest.Email, UserStatus.Unverified);
 
                     if (user == null)
                     {
@@ -98,7 +98,7 @@ namespace LBHFSSPortalAPI.V1.UseCase
 
         public void Resend(int userId)
         {
-            var userDomain = _usersGateway.GetUser(userId);
+            var userDomain = _usersGateway.GetUserById(userId);
 
             if (userDomain == null)
                 throw new UseCaseException()

--- a/LBHFSSPortalAPI/V1/UseCase/CreateUserRequestUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/CreateUserRequestUseCase.cs
@@ -61,7 +61,7 @@ namespace LBHFSSPortalAPI.V1.UseCase
             // check for currently active user with the same email address (prevents 2 active
             // users with the same email address in the database which can cause problems
             // elsewhere, e.g. 'login user')
-            var user = _usersGateway.GetUser(createRequestData.Email, UserStatus.Active);
+            var user = _usersGateway.GetUserByEmail(createRequestData.Email, UserStatus.Active);
 
             if (user != null)
                 throw new UseCaseException()
@@ -93,7 +93,7 @@ namespace LBHFSSPortalAPI.V1.UseCase
 
         private UserDomain SaveNewUser(UserCreateRequest createRequestData, string createdUserId)
         {
-            var user = _usersGateway.GetUser(createRequestData.Email, UserStatus.Invited);
+            var user = _usersGateway.GetUserByEmail(createRequestData.Email, UserStatus.Invited);
 
             if (user == null)
             {

--- a/LBHFSSPortalAPI/V1/UseCase/DeleteUserRequestUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/DeleteUserRequestUseCase.cs
@@ -23,7 +23,7 @@ namespace LBHFSSPortalAPI.V1.UseCase
         {
             bool success = false;
 
-            var user = _usersGateway.GetUser(userId);
+            var user = _usersGateway.GetUserById(userId);
 
             if (_authenticateGateway.DeleteUser(user.Email))
             {

--- a/LBHFSSPortalAPI/V1/UseCase/GetUserUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/GetUserUseCase.cs
@@ -18,7 +18,7 @@ namespace LBHFSSPortalAPI.V1.UseCase
 
         public async Task<UserResponse> Execute(int userId)
         {
-            var userDomain = await _usersGateway.GetUserAsync(userId).ConfigureAwait(false);
+            var userDomain = await _usersGateway.GetUserByIdAsync(userId).ConfigureAwait(false);
 
             if (userDomain == null)
                 throw new UseCaseException()

--- a/LBHFSSPortalAPI/V1/UseCase/UpdateUserRequestUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/UpdateUserRequestUseCase.cs
@@ -1,8 +1,14 @@
 using LBHFSSPortalAPI.V1.Boundary.Requests;
 using LBHFSSPortalAPI.V1.Boundary.Response;
+using LBHFSSPortalAPI.V1.Domain;
 using LBHFSSPortalAPI.V1.Exceptions;
+using LBHFSSPortalAPI.V1.Factories;
 using LBHFSSPortalAPI.V1.Gateways.Interfaces;
 using LBHFSSPortalAPI.V1.UseCase.Interfaces;
+using LBHFSSPortalAPI.V1.Validations;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace LBHFSSPortalAPI.V1.UseCase
 {
@@ -24,7 +30,7 @@ namespace LBHFSSPortalAPI.V1.UseCase
         public UserResponse Execute(int userId, UserUpdateRequest updateRequest)
         {
             ValidateRequestParams(updateRequest);
-            var userDomain = _usersGateway.GetUser(userId);
+            var userDomain = _usersGateway.GetUserById(userId);
 
             // We do not store the password in the API database so cannot tell here
             // if a different value was provided compared to the current value.
@@ -44,6 +50,8 @@ namespace LBHFSSPortalAPI.V1.UseCase
             userDomain.CreatedAt = updateRequest.CreatedAt ?? userDomain.CreatedAt;
             userDomain.Name = updateRequest.Name ?? userDomain.Name;
             userDomain.Status = updateRequest.Status ?? userDomain.Status;
+            userDomain = PopulateDomainWithUserRoles(userDomain, updateRequest.Roles);
+
             _usersGateway.UpdateUser(userDomain);
 
             var associatedOrg = _usersGateway.GetAssociatedOrganisation(userId);
@@ -81,39 +89,41 @@ namespace LBHFSSPortalAPI.V1.UseCase
                 }
             }
 
-            var response = new UserResponse()
-            {
-                CreatedAt = userDomain.CreatedAt,
-                Email = userDomain.Email,
-                Id = userDomain.Id,
-                Name = userDomain.Name,
-                Status = userDomain.Status,
-                SubId = userDomain.SubId
-            };
+            // refresh the user domain object after above changes
+            userDomain = _usersGateway.GetUserById(userDomain.Id);
 
-            if (associatedOrg != null)
+            return userDomain.ToResponse();
+        }
+
+        private static UserDomain PopulateDomainWithUserRoles(UserDomain userDomain, List<string> roles)
+        {
+            if (roles != null)
             {
-                // add organisation details to the response
-                response.Organisation = new OrganisationResponse()
+                // clear any current user roles
+                userDomain.UserRoles.Clear();
+
+                foreach (var role in roles)
                 {
-                    Id = associatedOrg.Id,
-                    Name = associatedOrg.Name
-                };
+                    // add the new roles from the request
+                    userDomain.UserRoles.Add(new UserRoleDomain()
+                    {
+                        User = userDomain,
+                        Role = new RoleDomain { Name = role }
+                    });
+                }
             }
 
-            return response;
+            return userDomain;
         }
 
         private static void ValidateRequestParams(UserUpdateRequest updateRequest)
         {
             const string EmptyFieldMessage =
-                "Send a(null) value for this if no change is required on this field";
+                "Send a (null) value for this if no change is required on this field";
 
             // The rather strange logic below is to account for the fact clients can send
             // a (null) value for a field in the request intending it to be ignored (keep
             // current value) but can also send a value if they wish it to be updated.
-            //
-            // TODO (MJC): (what if they want to empty one of the fields below such as roles?)
 
             if (updateRequest.Name != null && string.IsNullOrWhiteSpace(updateRequest.Name))
                 throw new UseCaseException()
@@ -133,13 +143,6 @@ namespace LBHFSSPortalAPI.V1.UseCase
                 throw new UseCaseException()
                 {
                     UserErrorMessage = "The provided user status was empty",
-                    DevErrorMessage = EmptyFieldMessage
-                };
-
-            if (updateRequest.Roles != null && string.IsNullOrWhiteSpace(updateRequest.Roles))
-                throw new UseCaseException()
-                {
-                    UserErrorMessage = "The provided user roles list was empty",
                     DevErrorMessage = EmptyFieldMessage
                 };
         }

--- a/LBHFSSPortalAPI/V1/Validations/UserRoleValidator.cs
+++ b/LBHFSSPortalAPI/V1/Validations/UserRoleValidator.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace LBHFSSPortalAPI.V1.Validations
+{
+    public static class UserRoleValidator
+    {
+        private static readonly List<string> _validUserRoles = new List<string> { "VSCO", "Viewer", "Admin" };
+
+        public static List<string> ToValidList(List<string> roles)
+        {
+            var validatedRoles = new List<string>();
+
+            if (roles != null)
+            {
+                foreach (var role in roles)
+                {
+                    foreach (var validRole in _validUserRoles)
+                    {
+                        if (role.Trim().ToLower(CultureInfo.CurrentCulture) == validRole.ToLower(CultureInfo.CurrentCulture))
+                        {
+                            validatedRoles.Add(validRole);
+                        }
+                    }
+                }
+            }
+
+            return validatedRoles;
+        }
+    }
+}

--- a/LBHFSSPortalAPI/V1/Validations/UserRoleValidator.cs
+++ b/LBHFSSPortalAPI/V1/Validations/UserRoleValidator.cs
@@ -5,7 +5,7 @@ namespace LBHFSSPortalAPI.V1.Validations
 {
     public static class UserRoleValidator
     {
-        private static readonly List<string> _validUserRoles = new List<string> { "VSCO", "Viewer", "Admin" };
+        private static readonly List<string> _validUserRoles = new List<string> { "VCSO", "Viewer", "Admin" };
 
         public static List<string> ToValidList(List<string> roles)
         {


### PR DESCRIPTION
New database column required on [user_roles] table and relationships modified. Hence entity framework changes required.
New behaviour allows adding user <-> roles association via all the endpoints which modify users. 