### PR TITLE
Services endpoints implementation

### DIFF
--- a/LBHFSSPortalAPI/V1/Boundary/Requests/CreateServiceRequest.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Requests/CreateServiceRequest.cs
@@ -4,10 +4,13 @@ using System.Text.Json.Serialization;
 
 namespace LBHFSSPortalAPI.V1.Boundary.Requests
 {
-    public class AddServiceRequest
+    public class CreateServiceRequest
     {
-        public int Id { get; set; }
-        public int? OrganizationId { get; set; }
+        public string Name { get; set; }
+
+        [JsonPropertyName("organisation_id")]
+        public int? OrganisationId { get; set; }
+
         public string Status { get; set; }
 
         [JsonPropertyName("created_at")]
@@ -16,7 +19,6 @@ namespace LBHFSSPortalAPI.V1.Boundary.Requests
         [JsonPropertyName("updated_at")]
         public DateTime? UpdatedAt { get; set; }
 
-        public string Name { get; set; }
         public string Description { get; set; }
         public string Website { get; set; }
         public string Email { get; set; }
@@ -33,10 +35,8 @@ namespace LBHFSSPortalAPI.V1.Boundary.Requests
         [JsonPropertyName("referral_email")]
         public string ReferralEmail { get; set; }
 
-        [JsonPropertyName("image_id")]
-        public int? ImageId { get; set; }
-
         public virtual ICollection<ServiceLocationRequest> Locations { get; set; }
         public virtual ICollection<TaxonomyRequest> Categories { get; set; }
+        public virtual ICollection<TaxonomyRequest> Demographics { get; set; }
     }
 }

--- a/LBHFSSPortalAPI/V1/Boundary/Requests/ServiceLocationRequest.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Requests/ServiceLocationRequest.cs
@@ -6,7 +6,7 @@ namespace LBHFSSPortalAPI.V1.Boundary.Requests
     {
         public decimal? Latitude { get; set; }
         public decimal? Longitude { get; set; }
-        public int? Uprn { get; set; }
+        public string Uprn { get; set; }
         public string Address1 { get; set; }
         public string City { get; set; }
 

--- a/LBHFSSPortalAPI/V1/Boundary/Requests/ServiceRequest.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Requests/ServiceRequest.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace LBHFSSPortalAPI.V1.Boundary.Requests
 {
-    public class CreateServiceRequest
+    public class ServiceRequest
     {
         public string Name { get; set; }
 
@@ -35,8 +35,8 @@ namespace LBHFSSPortalAPI.V1.Boundary.Requests
         [JsonPropertyName("referral_email")]
         public string ReferralEmail { get; set; }
 
-        public virtual ICollection<ServiceLocationRequest> Locations { get; set; }
-        public virtual ICollection<TaxonomyRequest> Categories { get; set; }
-        public virtual ICollection<TaxonomyRequest> Demographics { get; set; }
+        public virtual List<ServiceLocationRequest> Locations { get; set; }
+        public virtual List<TaxonomyRequest> Categories { get; set; }
+        public virtual List<int> Demographics { get; set; }
     }
 }

--- a/LBHFSSPortalAPI/V1/Boundary/Requests/TaxonomyRequest.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Requests/TaxonomyRequest.cs
@@ -5,14 +5,14 @@ namespace LBHFSSPortalAPI.V1.Boundary.Requests
 {
     public class TaxonomyRequest
     {
-        public int Id { get; set; }
+        public int? Id { get; set; }
         public string Name { get; set; }
         public string Vocabulary { get; set; }
 
         [JsonPropertyName("created_at")]
         public DateTime? CreatedAt { get; set; }
 
-        public int Weight { get; set; }
+        public int? Weight { get; set; }
         public string Description { get; set; }
     }
 }

--- a/LBHFSSPortalAPI/V1/Boundary/Response/AddressLookupResponse.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Response/AddressLookupResponse.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace LBHFSSPortalAPI.V1.Boundary.Response
+{
+    public class AddressLookupResponse
+    {
+        public decimal? Latitude { get; set; }
+        public decimal? Longitude { get; set; }
+        public int? Uprn { get; set; }
+
+        [JsonPropertyName("address_1")]
+        public string Address1 { get; set; }
+
+        [JsonPropertyName("address_2")]
+        public string Address2 { get; set; }
+
+        public string City { get; set; }
+
+        [JsonPropertyName("state_province")]
+        public string StateProvince { get; set; }
+
+        [JsonPropertyName("postal_code")]
+        public string PostalCode { get; set; }
+
+        public string Country { get; set; }
+    }
+}

--- a/LBHFSSPortalAPI/V1/Boundary/Response/LocationResponse.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Response/LocationResponse.cs
@@ -6,7 +6,7 @@ namespace LBHFSSPortalAPI.V1.Boundary.Response
     {
         public decimal? Latitude { get; set; }
         public decimal? Longitude { get; set; }
-        public int? Uprn { get; set; }
+        public string Uprn { get; set; }
         public string Address1 { get; set; }
         public string City { get; set; }
 

--- a/LBHFSSPortalAPI/V1/Controllers/AuthenticateController.cs
+++ b/LBHFSSPortalAPI/V1/Controllers/AuthenticateController.cs
@@ -73,7 +73,7 @@ namespace LBHFSSPortalAPI.V1.Controllers
         }
 
         [HttpPost]
-        [Route("registration/confirmation/resend")]
+        [Route("registration/confirmation/resend-request")]
         [ProducesResponseType(typeof(UsersResponseList), StatusCodes.Status200OK)]
         public IActionResult ResendConfirmationCode([FromBody] ConfirmationResendRequest confirmationResendRequest)
         {

--- a/LBHFSSPortalAPI/V1/Controllers/ServicesController.cs
+++ b/LBHFSSPortalAPI/V1/Controllers/ServicesController.cs
@@ -63,7 +63,7 @@ namespace LBHFSSPortalAPI.V1.Controllers
         [Route("services")]
         [HttpPost]
         [ProducesResponseType(typeof(ServiceResponse), StatusCodes.Status201Created)]
-        public async Task<IActionResult> AddService([FromBody] CreateServiceRequest request)
+        public async Task<IActionResult> AddService([FromBody] ServiceRequest request)
         {
             try
             {
@@ -76,14 +76,14 @@ namespace LBHFSSPortalAPI.V1.Controllers
             }
         }
 
-        [Route("services")]
+        [Route("services/{serviceId}")]
         [HttpPatch]
         [ProducesResponseType(typeof(ServiceResponse), StatusCodes.Status200OK)]
-        public async Task<IActionResult> UpdateService([FromBody] CreateServiceRequest request)
+        public async Task<IActionResult> UpdateService([FromBody] ServiceRequest request, [FromRoute] int serviceId)
         {
             try
             {
-                return Ok(await _updateServiceUseCase.Execute(request).ConfigureAwait(false));
+                return Ok(await _updateServiceUseCase.Execute(request, serviceId).ConfigureAwait(false));
             }
             catch (UseCaseException e)
             {

--- a/LBHFSSPortalAPI/V1/Controllers/ServicesController.cs
+++ b/LBHFSSPortalAPI/V1/Controllers/ServicesController.cs
@@ -63,7 +63,7 @@ namespace LBHFSSPortalAPI.V1.Controllers
         [Route("services")]
         [HttpPost]
         [ProducesResponseType(typeof(ServiceResponse), StatusCodes.Status201Created)]
-        public async Task<IActionResult> AddService([FromBody] AddServiceRequest request)
+        public async Task<IActionResult> AddService([FromBody] CreateServiceRequest request)
         {
             try
             {
@@ -79,7 +79,7 @@ namespace LBHFSSPortalAPI.V1.Controllers
         [Route("services")]
         [HttpPatch]
         [ProducesResponseType(typeof(ServiceResponse), StatusCodes.Status200OK)]
-        public async Task<IActionResult> UpdateService([FromBody] AddServiceRequest request)
+        public async Task<IActionResult> UpdateService([FromBody] CreateServiceRequest request)
         {
             try
             {

--- a/LBHFSSPortalAPI/V1/Controllers/ServicesController.cs
+++ b/LBHFSSPortalAPI/V1/Controllers/ServicesController.cs
@@ -106,5 +106,35 @@ namespace LBHFSSPortalAPI.V1.Controllers
                 return BadRequest(e);
             }
         }
+
+        [Route("address-lookup")]
+        [HttpGet]
+        [ProducesResponseType(typeof(List<AddressLookupResponse>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> LookupAddress([FromQuery] string postcode)
+        {
+            try
+            {
+                var response = new AddressLookupResponse()
+                {
+                    Longitude = 999,
+                    Latitude = 999,
+                    Uprn = 999,
+                    Address1 = "NOT_YET_IMPLEMENTED_STUBBED_DATA",
+                    Address2 = "NOT_YET_IMPLEMENTED_STUBBED_DATA",
+                    City = "NOT_YET_IMPLEMENTED_STUBBED_DATA",
+                    StateProvince = "NOT_YET_IMPLEMENTED_STUBBED_DATA",
+                    PostalCode = postcode ?? "NOT_YET_IMPLEMENTED_STUBBED_DATA",
+                    Country = "NOT_YET_IMPLEMENTED_STUBBED_DATA"
+                };
+
+                return Ok(response);
+                //return Ok(await _getServicesUseCase.LookupAddress(queryParam).ConfigureAwait(false));
+            }
+            catch (UseCaseException e)
+            {
+                return BadRequest(e);
+            }
+        }
+
     }
 }

--- a/LBHFSSPortalAPI/V1/Factories/MappingHelper.cs
+++ b/LBHFSSPortalAPI/V1/Factories/MappingHelper.cs
@@ -11,7 +11,7 @@ namespace LBHFSSPortalAPI.V1.Factories
     /// </summary>
     public class MappingHelper
     {
-        private Mapper _mapper;
+        private readonly Mapper _mapper;
 
         public MappingHelper()
         {

--- a/LBHFSSPortalAPI/V1/Factories/ServiceResponseFactory.cs
+++ b/LBHFSSPortalAPI/V1/Factories/ServiceResponseFactory.cs
@@ -41,7 +41,7 @@ namespace LBHFSSPortalAPI.V1.Factories
                         {
                             Latitude = domain.Latitude,
                             Longitude = domain.Longitude,
-                            Uprn = domain.Uprn,
+                            Uprn = "STUBBED_FIELD_DATABASE_CHANGE_REQUIRED",  //domain.Uprn, DATABASE CHANGE REQUIRED - NEEDS TO BE A STRING!
                             Address1 = domain.Address1,
                             City = domain.City,
                             StateProvince = domain.StateProvince,

--- a/LBHFSSPortalAPI/V1/Gateways/BaseGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/BaseGateway.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace LBHFSSPortalAPI.V1.Gateways
 {
-    public class BaseGateway
+    public abstract class BaseGateway
     {
         protected DatabaseContext Context { get; set; }
 
@@ -16,7 +16,7 @@ namespace LBHFSSPortalAPI.V1.Gateways
             Context = databaseContext;
         }
 
-        public static void HandleDbUpdateException(DbUpdateException e)
+        protected static void HandleDbUpdateException(DbUpdateException e)
         {
             var uce = new UseCaseException()
             {

--- a/LBHFSSPortalAPI/V1/Gateways/BaseGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/BaseGateway.cs
@@ -55,19 +55,22 @@ namespace LBHFSSPortalAPI.V1.Gateways
         /// <returns></returns>
         protected string GetEntityPropertyForColumnName(Type type, string columnToFind)
         {
-            var entityType = Context.Model.FindEntityType(type.FullName);
-
-            if (entityType != null)
+            if (columnToFind != null)
             {
-                columnToFind = columnToFind.Trim().ToLower(CultureInfo.CurrentCulture);
+                var entityType = Context.Model.FindEntityType(type.FullName);
 
-                foreach (var prop in entityType.GetProperties())
+                if (entityType != null)
                 {
-                    var columnName = prop.GetColumnName();
+                    columnToFind = columnToFind.Trim().ToLower(CultureInfo.CurrentCulture);
 
-                    if (string.Compare(columnToFind, columnName, true, CultureInfo.CurrentCulture) == 0)
+                    foreach (var prop in entityType.GetProperties())
                     {
-                        return prop.Name;
+                        var columnName = prop.GetColumnName();
+
+                        if (string.Compare(columnToFind, columnName, true, CultureInfo.CurrentCulture) == 0)
+                        {
+                            return prop.Name;
+                        }
                     }
                 }
             }

--- a/LBHFSSPortalAPI/V1/Gateways/Interfaces/IServicesGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/Interfaces/IServicesGateway.cs
@@ -1,5 +1,4 @@
 using LBHFSSPortalAPI.V1.Boundary.Requests;
-using LBHFSSPortalAPI.V1.Boundary.Response;
 using LBHFSSPortalAPI.V1.Domain;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -10,6 +9,8 @@ namespace LBHFSSPortalAPI.V1.Gateways.Interfaces
     {
         Task<ServiceDomain> GetServiceAsync(int serviceId);
         Task<List<ServiceDomain>> GetServicesAsync(ServicesQueryParam servicesQuery);
-        Task<ServiceResponse> CreateService(CreateServiceRequest request);
+        Task<ServiceDomain> CreateService(ServiceRequest request);
+        Task DeleteService(int serviceId);
+        Task<ServiceDomain> UpdateService(ServiceRequest request, int serviceId);
     }
 }

--- a/LBHFSSPortalAPI/V1/Gateways/Interfaces/IServicesGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/Interfaces/IServicesGateway.cs
@@ -1,4 +1,5 @@
 using LBHFSSPortalAPI.V1.Boundary.Requests;
+using LBHFSSPortalAPI.V1.Boundary.Response;
 using LBHFSSPortalAPI.V1.Domain;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -9,5 +10,6 @@ namespace LBHFSSPortalAPI.V1.Gateways.Interfaces
     {
         Task<ServiceDomain> GetServiceAsync(int serviceId);
         Task<List<ServiceDomain>> GetServicesAsync(ServicesQueryParam servicesQuery);
+        Task<ServiceResponse> CreateService(CreateServiceRequest request);
     }
 }

--- a/LBHFSSPortalAPI/V1/Gateways/ServiceStatus.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/ServiceStatus.cs
@@ -1,0 +1,9 @@
+namespace LBHFSSPortalAPI.V1.Gateways
+{
+    public static class ServiceStatus
+    {
+        public const string Created = "created";
+        public const string Deleted = "deleted";
+        public const string Updated = "updated";
+    }
+}

--- a/LBHFSSPortalAPI/V1/Gateways/ServicesGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/ServicesGateway.cs
@@ -75,7 +75,7 @@ namespace LBHFSSPortalAPI.V1.Gateways
                         {
                             TaxonomyId = c.Id,
                             //D
-                            
+
                         })
                         .ToList());
             }

--- a/LBHFSSPortalAPI/V1/Gateways/ServicesGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/ServicesGateway.cs
@@ -289,7 +289,7 @@ namespace LBHFSSPortalAPI.V1.Gateways
                         Latitude = l.Latitude,
                         Longitude = l.Longitude,
                         Uprn = 0, //l.Uprn, DATABASE CHANGE REQUIRED - NEEDS TO BE A STRING!
-                    Address1 = l.Address1,
+                        Address1 = l.Address1,
                         City = l.City,
                         StateProvince = l.StateProvince,
                         PostalCode = l.PostalCode,

--- a/LBHFSSPortalAPI/V1/Gateways/ServicesGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/ServicesGateway.cs
@@ -22,18 +22,34 @@ namespace LBHFSSPortalAPI.V1.Gateways
             _mapper = new MappingHelper();
         }
 
-        public Task<ServiceResponse> CreateService(CreateServiceRequest request)
+        public async Task<ServiceDomain> CreateService(ServiceRequest request)
         {
             if (request == null)
                 throw new UseCaseException
                 {
-                    UserErrorMessage = "Could not add a new service, valid request was not provided"
+                    UserErrorMessage = "Could not add a new service, a valid 'create service' request was not provided"
+                };
+
+            if (!request.OrganisationId.HasValue)
+                throw new UseCaseException()
+                {
+                    UserErrorMessage = "Service cannot be added as the provided organisation ID was not valid"
+                };
+
+            var organisation = await Context.Organizations
+                .FirstOrDefaultAsync(o => o.Id == request.OrganisationId)
+                .ConfigureAwait(false);
+
+            if (organisation == null)
+                throw new UseCaseException()
+                {
+                    UserErrorMessage = $"Could not find organisation ID '{request.OrganisationId}'"
                 };
 
             var service = new Service()
             {
                 Name = request.Name,
-                Status = request.Status,
+                Status = request.Status ?? ServiceStatus.Created,
                 CreatedAt = request.CreatedAt ?? DateTime.UtcNow,
                 UpdatedAt = request.UpdatedAt,
                 Description = request.Description,
@@ -54,7 +70,7 @@ namespace LBHFSSPortalAPI.V1.Gateways
                     {
                         Latitude = l.Latitude,
                         Longitude = l.Longitude,
-                        Uprn = l.Uprn,
+                        Uprn = 0, //l.Uprn, DATABASE CHANGE REQUIRED - NEEDS TO BE A STRING!
                         Address1 = l.Address1,
                         City = l.City,
                         StateProvince = l.StateProvince,
@@ -65,48 +81,75 @@ namespace LBHFSSPortalAPI.V1.Gateways
                 ServiceTaxonomies = new List<ServiceTaxonomy>(),
             };
 
-            var taxonomies = new List<ServiceTaxonomy>();
-
-            if (request.Categories != null && request.Categories.Any())
+            // business rule: if no service name is provided, default to the Organisation name
+            if (string.IsNullOrWhiteSpace(service.Name))
             {
-                taxonomies.AddRange(
-                    request.Categories
-                        .Select(c => new ServiceTaxonomy()
-                        {
-                            TaxonomyId = c.Id,
-                            //D
-
-                        })
-                        .ToList());
+                service.Name = organisation.Name;
             }
 
-            if (request.Demographics != null && request.Demographics.Any())
+            // TODO (MJC): Implement the below next week to associate service with categories & demographics.
+
+            //var taxonomies = new List<ServiceTaxonomy>();
+
+            //if (request.Categories != null && request.Categories.Any())
+            //{
+            //    taxonomies.AddRange(
+            //        request.Categories
+            //            .Select(c => new ServiceTaxonomy()
+            //            {
+            //                TaxonomyId = c.Id,
+            //                //D
+
+            //            })
+            //            .ToList());
+            //}
+
+            //if (request.Demographics != null && request.Demographics.Any())
+            //{
+            //    taxonomies.AddRange(
+            //        request.Demographics
+            //            .Select(c => new ServiceTaxonomy()
+            //            {
+            //                TaxonomyId = c.Id
+            //            })
+            //            .ToList());
+            //}
+
+            try
             {
-                taxonomies.AddRange(
-                    request.Demographics
-                        .Select(c => new ServiceTaxonomy()
-                        {
-                            TaxonomyId = c.Id
-                        })
-                        .ToList());
+                Context.Services.Add(service);
+                Context.SaveChanges();
+            }
+            catch (DbUpdateException e)
+            {
+                HandleDbUpdateException(e);
             }
 
-            return null;
+            // Get fresh copy of the service from the database
+            service = await GetServiceById(service.Id).ConfigureAwait(false);
+            var serviceDomain = _mapper.ToDomain(service);
+
+            return serviceDomain;
+        }
+
+        public async Task DeleteService(int serviceId)
+        {
+            try
+            {
+                var service = await GetServiceById(serviceId).ConfigureAwait(false);
+                service.Status = ServiceStatus.Deleted;
+                Context.Update(service);
+                await Context.SaveChangesAsync().ConfigureAwait(false);
+            }
+            catch (DbUpdateException e)
+            {
+                HandleDbUpdateException(e);
+            }
         }
 
         public async Task<ServiceDomain> GetServiceAsync(int serviceId)
         {
-            var service = await Context.Services
-                .Include(s => s.Organization)
-                .ThenInclude(o => o.UserOrganizations)
-                .ThenInclude(uo => uo.User)
-                .Include(s => s.Image)
-                .Include(s => s.ServiceLocations)
-                .Include(s => s.ServiceTaxonomies)
-                .ThenInclude(st => st.Taxonomy)
-                .AsNoTracking()
-                .SingleOrDefaultAsync(u => u.Id == serviceId)
-                .ConfigureAwait(false);
+            var service = await GetServiceById(serviceId).ConfigureAwait(false);
 
             if (service != null)
                 return _mapper.ToDomain(service);
@@ -161,6 +204,7 @@ namespace LBHFSSPortalAPI.V1.Gateways
             try
             {
                 var services = await matchingServices
+                    .Where(s => s.Status != ServiceStatus.Deleted)
                     .Include(s => s.Organization)
                     .ThenInclude(o => o.UserOrganizations)
                     .ThenInclude(uo => uo.User)
@@ -185,5 +229,143 @@ namespace LBHFSSPortalAPI.V1.Gateways
 
             return response;
         }
+
+        public async Task<ServiceDomain> UpdateService(ServiceRequest request, int serviceId)
+        {
+            if (request == null)
+                throw new UseCaseException
+                {
+                    UserErrorMessage = "Could not add a new service, a valid 'create service' request was not provided"
+                };
+
+            if (!request.OrganisationId.HasValue)
+                throw new UseCaseException()
+                {
+                    UserErrorMessage = "Service cannot be added as the provided organisation ID was not valid"
+                };
+
+            var organisation = await Context.Organizations
+                .FirstOrDefaultAsync(o => o.Id == request.OrganisationId)
+                .ConfigureAwait(false);
+
+            if (organisation == null)
+                throw new UseCaseException()
+                {
+                    UserErrorMessage = $"Could not find organisation ID {request.OrganisationId}"
+                };
+
+            var service = await GetServiceById(serviceId).ConfigureAwait(false);
+
+            if (service == null)
+                throw new UseCaseException()
+                {
+                    UserErrorMessage = $"Could not find a service with the given ID {serviceId}"
+                };
+
+            service.Name = request.Name ?? service.Name;
+            service.Status = request.Status ?? ServiceStatus.Updated;
+            service.CreatedAt = request.CreatedAt ?? service.CreatedAt;
+            service.UpdatedAt = DateTime.UtcNow;
+            service.Description = request.Description ?? service.Description;
+            service.Website = request.Website ?? service.Website;
+            service.Email = request.Email ?? service.Email;
+            service.Telephone = request.Telephone ?? service.Telephone;
+            service.Facebook = request.Facebook ?? service.Facebook;
+            service.Twitter = request.Twitter ?? service.Twitter;
+            service.Instagram = request.Instagram ?? service.Instagram;
+            service.Linkedin = request.Linkedin ?? service.Linkedin;
+            service.Keywords = request.Keywords ?? service.Keywords;
+            service.ReferralLink = request.ReferralLink ?? service.ReferralLink;
+            service.ReferralEmail = request.ReferralEmail ?? service.ReferralEmail;
+
+            service.Organization = null;
+            service.OrganizationId = request.OrganisationId ?? service.OrganizationId;
+
+            if (request.Locations != null)
+            {
+                service.ServiceLocations = request.Locations
+                    .Select(l => new ServiceLocation()
+                    {
+                        Latitude = l.Latitude,
+                        Longitude = l.Longitude,
+                        Uprn = 0, //l.Uprn, DATABASE CHANGE REQUIRED - NEEDS TO BE A STRING!
+                    Address1 = l.Address1,
+                        City = l.City,
+                        StateProvince = l.StateProvince,
+                        PostalCode = l.PostalCode,
+                        Country = l.Country
+                    })
+                    .ToList();
+            }
+
+            // business rule: if no service name is provided, default to the Organisation name
+            if (string.IsNullOrWhiteSpace(service.Name))
+            {
+                service.Name = organisation.Name;
+            }
+
+            // TODO (MJC): Implement the below next week to associate service with categories & demographics.
+
+            //var taxonomies = new List<ServiceTaxonomy>();
+
+            //if (request.Categories != null && request.Categories.Any())
+            //{
+            //    taxonomies.AddRange(
+            //        request.Categories
+            //            .Select(c => new ServiceTaxonomy()
+            //            {
+            //                TaxonomyId = c.Id,
+            //                //D
+
+            //            })
+            //            .ToList());
+            //}
+
+            //if (request.Demographics != null && request.Demographics.Any())
+            //{
+            //    taxonomies.AddRange(
+            //        request.Demographics
+            //            .Select(c => new ServiceTaxonomy()
+            //            {
+            //                TaxonomyId = c.Id
+            //            })
+            //            .ToList());
+            //}
+
+            try
+            {
+                Context.Update(service);
+                await Context.SaveChangesAsync().ConfigureAwait(false);
+            }
+            catch (DbUpdateException e)
+            {
+                HandleDbUpdateException(e);
+            }
+
+            // Get fresh copy of the service from the database
+            service = await GetServiceById(service.Id).ConfigureAwait(false);
+            var serviceDomain = _mapper.ToDomain(service);
+
+            return serviceDomain;
+        }
+
+        private async Task<Service> GetServiceById(int serviceId)
+        {
+            var service = await Context.Services
+                .Where(s => s.Status != ServiceStatus.Deleted)
+                .Include(s => s.Organization)
+                .ThenInclude(o => o.UserOrganizations)
+                .ThenInclude(uo => uo.User)
+                .Include(s => s.Image)
+                .Include(s => s.ServiceLocations)
+                .Include(s => s.ServiceTaxonomies)
+                .ThenInclude(st => st.Taxonomy)
+                .AsNoTracking()
+                .SingleOrDefaultAsync(u => u.Id == serviceId)
+                .ConfigureAwait(false);
+
+            return service;
+        }
     }
 }
+

--- a/LBHFSSPortalAPI/V1/Gateways/ServicesGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/ServicesGateway.cs
@@ -1,4 +1,5 @@
 using LBHFSSPortalAPI.V1.Boundary.Requests;
+using LBHFSSPortalAPI.V1.Boundary.Response;
 using LBHFSSPortalAPI.V1.Domain;
 using LBHFSSPortalAPI.V1.Exceptions;
 using LBHFSSPortalAPI.V1.Factories;
@@ -19,6 +20,78 @@ namespace LBHFSSPortalAPI.V1.Gateways
         public ServicesGateway(DatabaseContext context) : base(context)
         {
             _mapper = new MappingHelper();
+        }
+
+        public Task<ServiceResponse> CreateService(CreateServiceRequest request)
+        {
+            if (request == null)
+                throw new UseCaseException
+                {
+                    UserErrorMessage = "Could not add a new service, valid request was not provided"
+                };
+
+            var service = new Service()
+            {
+                Name = request.Name,
+                Status = request.Status,
+                CreatedAt = request.CreatedAt ?? DateTime.UtcNow,
+                UpdatedAt = request.UpdatedAt,
+                Description = request.Description,
+                Website = request.Website,
+                Email = request.Email,
+                Telephone = request.Telephone,
+                Facebook = request.Facebook,
+                Twitter = request.Twitter,
+                Instagram = request.Instagram,
+                Linkedin = request.Linkedin,
+                Keywords = request.Keywords,
+                ReferralLink = request.ReferralLink,
+                ReferralEmail = request.ReferralEmail,
+                OrganizationId = request.OrganisationId,
+
+                ServiceLocations = request?.Locations
+                    .Select(l => new ServiceLocation()
+                    {
+                        Latitude = l.Latitude,
+                        Longitude = l.Longitude,
+                        Uprn = l.Uprn,
+                        Address1 = l.Address1,
+                        City = l.City,
+                        StateProvince = l.StateProvince,
+                        PostalCode = l.PostalCode,
+                        Country = l.Country
+                    })
+                    .ToList(),
+                ServiceTaxonomies = new List<ServiceTaxonomy>(),
+            };
+
+            var taxonomies = new List<ServiceTaxonomy>();
+
+            if (request.Categories != null && request.Categories.Any())
+            {
+                taxonomies.AddRange(
+                    request.Categories
+                        .Select(c => new ServiceTaxonomy()
+                        {
+                            TaxonomyId = c.Id,
+                            //D
+                            
+                        })
+                        .ToList());
+            }
+
+            if (request.Demographics != null && request.Demographics.Any())
+            {
+                taxonomies.AddRange(
+                    request.Demographics
+                        .Select(c => new ServiceTaxonomy()
+                        {
+                            TaxonomyId = c.Id
+                        })
+                        .ToList());
+            }
+
+            return null;
         }
 
         public async Task<ServiceDomain> GetServiceAsync(int serviceId)

--- a/LBHFSSPortalAPI/V1/Infrastructure/DatabaseContext.cs
+++ b/LBHFSSPortalAPI/V1/Infrastructure/DatabaseContext.cs
@@ -188,6 +188,10 @@ namespace LBHFSSPortalAPI.V1.Infrastructure
                     .HasColumnName("address_1")
                     .HasColumnType("character varying");
 
+                entity.Property(e => e.Address2)
+                    .HasColumnName("address_2")
+                    .HasColumnType("character varying");
+
                 entity.Property(e => e.City)
                     .HasColumnName("city")
                     .HasColumnType("character varying");
@@ -421,6 +425,10 @@ namespace LBHFSSPortalAPI.V1.Infrastructure
 
                 entity.Property(e => e.Vocabulary)
                     .HasColumnName("vocabulary")
+                    .HasColumnType("character varying");
+
+                entity.Property(e => e.Description)
+                    .HasColumnName("description")
                     .HasColumnType("character varying");
 
                 entity.Property(e => e.Weight).HasColumnName("weight");

--- a/LBHFSSPortalAPI/V1/Infrastructure/ServiceLocation.cs
+++ b/LBHFSSPortalAPI/V1/Infrastructure/ServiceLocation.cs
@@ -10,6 +10,7 @@ namespace LBHFSSPortalAPI.V1.Infrastructure
         public decimal? Longitude { get; set; }
         public int? Uprn { get; set; }
         public string Address1 { get; set; }
+        public string Address2 { get; set; }
         public string City { get; set; }
         public string StateProvince { get; set; }
         public string PostalCode { get; set; }

--- a/LBHFSSPortalAPI/V1/Infrastructure/ServiceTaxonomy.cs
+++ b/LBHFSSPortalAPI/V1/Infrastructure/ServiceTaxonomy.cs
@@ -4,8 +4,8 @@ namespace LBHFSSPortalAPI.V1.Infrastructure
     public partial class ServiceTaxonomy
     {
         public int Id { get; set; }
-        public int? ServiceId { get; set; }
-        public int? TaxonomyId { get; set; }
+        public int ServiceId { get; set; }
+        public int TaxonomyId { get; set; }
         public string Description { get; set; }
 
         public virtual Service Service { get; set; }

--- a/LBHFSSPortalAPI/V1/UseCase/CreateServiceUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/CreateServiceUseCase.cs
@@ -1,15 +1,34 @@
-using System.Threading.Tasks;
 using LBHFSSPortalAPI.V1.Boundary.Requests;
 using LBHFSSPortalAPI.V1.Boundary.Response;
+using LBHFSSPortalAPI.V1.Domain;
+using LBHFSSPortalAPI.V1.Exceptions;
+using LBHFSSPortalAPI.V1.Factories;
+using LBHFSSPortalAPI.V1.Gateways.Interfaces;
 using LBHFSSPortalAPI.V1.UseCase.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace LBHFSSPortalAPI.V1.UseCase
 {
     public class CreateServiceUseCase : ICreateServiceUseCase
     {
-        public Task<ServiceResponse> Execute(AddServiceRequest request)
+        private readonly IServicesGateway _servicesGateway;
+
+        public CreateServiceUseCase(IServicesGateway servicesGateway)
         {
-            throw new System.NotImplementedException();
+            _servicesGateway = servicesGateway;
+        }
+
+        public async Task<ServiceResponse> Execute(CreateServiceRequest request)
+        {
+            Validate(request);
+
+            return await _servicesGateway.CreateService(request).ConfigureAwait(false);
+        }
+
+        private void Validate(CreateServiceRequest request)
+        {
         }
     }
 }

--- a/LBHFSSPortalAPI/V1/UseCase/CreateServiceUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/CreateServiceUseCase.cs
@@ -1,12 +1,8 @@
 using LBHFSSPortalAPI.V1.Boundary.Requests;
 using LBHFSSPortalAPI.V1.Boundary.Response;
-using LBHFSSPortalAPI.V1.Domain;
-using LBHFSSPortalAPI.V1.Exceptions;
 using LBHFSSPortalAPI.V1.Factories;
 using LBHFSSPortalAPI.V1.Gateways.Interfaces;
 using LBHFSSPortalAPI.V1.UseCase.Interfaces;
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace LBHFSSPortalAPI.V1.UseCase
@@ -20,15 +16,17 @@ namespace LBHFSSPortalAPI.V1.UseCase
             _servicesGateway = servicesGateway;
         }
 
-        public async Task<ServiceResponse> Execute(CreateServiceRequest request)
+        public async Task<ServiceResponse> Execute(ServiceRequest request)
         {
             Validate(request);
+            var serviceDomain = await _servicesGateway.CreateService(request).ConfigureAwait(false);
 
-            return await _servicesGateway.CreateService(request).ConfigureAwait(false);
+            return serviceDomain.ToResponse();
         }
 
-        private void Validate(CreateServiceRequest request)
+        private void Validate(ServiceRequest request)
         {
+            // all fine for now :)
         }
     }
 }

--- a/LBHFSSPortalAPI/V1/UseCase/DeleteServiceUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/DeleteServiceUseCase.cs
@@ -1,3 +1,4 @@
+using LBHFSSPortalAPI.V1.Gateways.Interfaces;
 using LBHFSSPortalAPI.V1.UseCase.Interfaces;
 using System.Threading.Tasks;
 
@@ -5,9 +6,16 @@ namespace LBHFSSPortalAPI.V1.UseCase
 {
     public class DeleteServiceUseCase : IDeleteServiceUseCase
     {
-        public Task Execute(int serviceId)
+        private readonly IServicesGateway _servicesGateway;
+
+        public DeleteServiceUseCase(IServicesGateway servicesGateway)
         {
-            throw new System.NotImplementedException();
+            _servicesGateway = servicesGateway;
+        }
+
+        public async Task Execute(int serviceId)
+        {
+            await _servicesGateway.DeleteService(serviceId).ConfigureAwait(false);
         }
     }
 }

--- a/LBHFSSPortalAPI/V1/UseCase/Interfaces/ICreateServiceUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/Interfaces/ICreateServiceUseCase.cs
@@ -6,6 +6,6 @@ namespace LBHFSSPortalAPI.V1.UseCase.Interfaces
 {
     public interface ICreateServiceUseCase
     {
-        Task<ServiceResponse> Execute(AddServiceRequest request);
+        Task<ServiceResponse> Execute(CreateServiceRequest request);
     }
 }

--- a/LBHFSSPortalAPI/V1/UseCase/Interfaces/ICreateServiceUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/Interfaces/ICreateServiceUseCase.cs
@@ -6,6 +6,6 @@ namespace LBHFSSPortalAPI.V1.UseCase.Interfaces
 {
     public interface ICreateServiceUseCase
     {
-        Task<ServiceResponse> Execute(CreateServiceRequest request);
+        Task<ServiceResponse> Execute(ServiceRequest request);
     }
 }

--- a/LBHFSSPortalAPI/V1/UseCase/Interfaces/IUpdateServiceUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/Interfaces/IUpdateServiceUseCase.cs
@@ -6,6 +6,6 @@ namespace LBHFSSPortalAPI.V1.UseCase.Interfaces
 {
     public interface IUpdateServiceUseCase
     {
-        Task<ServiceResponse> Execute(CreateServiceRequest request);
+        Task<ServiceResponse> Execute(ServiceRequest request, int serviceId);
     }
 }

--- a/LBHFSSPortalAPI/V1/UseCase/Interfaces/IUpdateServiceUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/Interfaces/IUpdateServiceUseCase.cs
@@ -6,6 +6,6 @@ namespace LBHFSSPortalAPI.V1.UseCase.Interfaces
 {
     public interface IUpdateServiceUseCase
     {
-        Task<ServiceResponse> Execute(AddServiceRequest request);
+        Task<ServiceResponse> Execute(CreateServiceRequest request);
     }
 }

--- a/LBHFSSPortalAPI/V1/UseCase/UpdateServiceUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/UpdateServiceUseCase.cs
@@ -1,5 +1,7 @@
 using LBHFSSPortalAPI.V1.Boundary.Requests;
 using LBHFSSPortalAPI.V1.Boundary.Response;
+using LBHFSSPortalAPI.V1.Factories;
+using LBHFSSPortalAPI.V1.Gateways.Interfaces;
 using LBHFSSPortalAPI.V1.UseCase.Interfaces;
 using System.Threading.Tasks;
 
@@ -7,9 +9,24 @@ namespace LBHFSSPortalAPI.V1.UseCase
 {
     public class UpdateServiceUseCase : IUpdateServiceUseCase
     {
-        public Task<ServiceResponse> Execute(CreateServiceRequest request)
+        private readonly IServicesGateway _servicesGateway;
+
+        public UpdateServiceUseCase(IServicesGateway servicesGateway)
         {
-            throw new System.NotImplementedException();
+            _servicesGateway = servicesGateway;
+        }
+
+        public async Task<ServiceResponse> Execute(ServiceRequest request, int serviceId)
+        {
+            Validate(request);
+            var serviceDomain = await _servicesGateway.UpdateService(request, serviceId).ConfigureAwait(false);
+
+            return serviceDomain.ToResponse();
+        }
+
+        private void Validate(ServiceRequest request)
+        {
+            // all fine for now :)
         }
     }
 }

--- a/LBHFSSPortalAPI/V1/UseCase/UpdateServiceUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/UpdateServiceUseCase.cs
@@ -7,7 +7,7 @@ namespace LBHFSSPortalAPI.V1.UseCase
 {
     public class UpdateServiceUseCase : IUpdateServiceUseCase
     {
-        public Task<ServiceResponse> Execute(AddServiceRequest request)
+        public Task<ServiceResponse> Execute(CreateServiceRequest request)
         {
             throw new System.NotImplementedException();
         }


### PR DESCRIPTION
PR contains the below items:

- Implementation of GET /service, GET/services/{serviceId} 
- Implementation of POST, PATCH and DELETE /services (still to add: associations to categories/demographics, image upload, image resizing)
- Schema / EF code changes merged from the Public API project
- Update to endpoint route '/registration/confirmation/resend ' -> 'registration/confirmation/resend-request'
- Stubbed endpoint for GET /address-lookup (still to be fully implemented)
- Bug fixes from testing 
