### PR TITLE
Implement service categories/demographics functionality 

### DIFF
--- a/LBHFSSPortalAPI/V1/Boundary/Requests/TaxonomyRequest.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Requests/TaxonomyRequest.cs
@@ -1,18 +1,9 @@
-using System;
-using System.Text.Json.Serialization;
 
 namespace LBHFSSPortalAPI.V1.Boundary.Requests
 {
     public class TaxonomyRequest
     {
-        public int? Id { get; set; }
-        public string Name { get; set; }
-        public string Vocabulary { get; set; }
-
-        [JsonPropertyName("created_at")]
-        public DateTime? CreatedAt { get; set; }
-
-        public int? Weight { get; set; }
+        public int Id { get; set; }
         public string Description { get; set; }
     }
 }

--- a/LBHFSSPortalAPI/V1/Boundary/Response/TaxonomyResponse.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Response/TaxonomyResponse.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace LBHFSSPortalAPI.V1.Boundary.Response
 {
     public class TaxonomyResponse
@@ -7,5 +9,8 @@ namespace LBHFSSPortalAPI.V1.Boundary.Response
         public string Description { get; set; }
         public string Vocabulary { get; set; }
         public int Weight { get; set; }
+
+        [JsonPropertyName("service_description")]
+        public string ServiceDescription { get; set; }
     }
 }

--- a/LBHFSSPortalAPI/V1/Domain/TaxonomyVocabulary.cs
+++ b/LBHFSSPortalAPI/V1/Domain/TaxonomyVocabulary.cs
@@ -1,0 +1,9 @@
+
+namespace LBHFSSPortalAPI.V1.Domain
+{
+    public static class TaxonomyVocabulary
+    {
+        public const string Category = "category";
+        public const string Demographic = "demographic";
+    }
+}

--- a/LBHFSSPortalAPI/V1/Factories/ServiceResponseFactory.cs
+++ b/LBHFSSPortalAPI/V1/Factories/ServiceResponseFactory.cs
@@ -60,24 +60,26 @@ namespace LBHFSSPortalAPI.V1.Factories
                     Categories = domain.ServiceTaxonomies == null
                     ? null
                     : domain.ServiceTaxonomies
-                        .Where(t => t.Taxonomy != null && t.Taxonomy.Vocabulary == "category")
+                        .Where(t => t.Taxonomy != null && t.Taxonomy.Vocabulary == TaxonomyVocabulary.Category)
                         .Select(t => new TaxonomyResponse
                         {
                             Id = t.Taxonomy.Id,
                             Name = t.Taxonomy.Name,
                             Description = t.Taxonomy.Description,
+                            ServiceDescription = t.Description,
                             Vocabulary = t.Taxonomy.Vocabulary,
                             Weight = t.Taxonomy.Weight
                         }).ToList(),
                     Demographics = domain.ServiceTaxonomies == null
                     ? null
                     : domain.ServiceTaxonomies
-                        .Where(t => t.Taxonomy != null && t.Taxonomy.Vocabulary == "demographic")
+                        .Where(t => t.Taxonomy != null && t.Taxonomy.Vocabulary == TaxonomyVocabulary.Demographic)
                         .Select(t => new TaxonomyResponse()
                         {
                             Id = t.Taxonomy.Id,
                             Name = t.Taxonomy.Name,
                             Description = t.Taxonomy.Description,
+                            ServiceDescription = t.Description,
                             Vocabulary = t.Taxonomy.Vocabulary,
                             Weight = t.Taxonomy.Weight
                         })

--- a/LBHFSSPortalAPI/V1/Gateways/ServicesGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/ServicesGateway.cs
@@ -287,7 +287,7 @@ namespace LBHFSSPortalAPI.V1.Gateways
             // Add the category taxonomies if provided
 
             var currentTaxonomies = service.ServiceTaxonomies.ToList();
-            
+
             if (request.Categories != null)
             {
                 // Clear existing categories. Note: if an empty list of categories is sent, this is a valid

--- a/LBHFSSPortalAPI/V1/Gateways/UsersGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/UsersGateway.cs
@@ -61,11 +61,11 @@ namespace LBHFSSPortalAPI.V1.Gateways
                 matchingUsers.OrderByDescending(u => EF.Property<User>(u, entityPropName));
 
             // handle pagination options
-            if (userQueryParam.Limit.HasValue)
-                matchingUsers = matchingUsers.Take(userQueryParam.Limit.Value);
-
             if (userQueryParam.Offset.HasValue)
                 matchingUsers = matchingUsers.Skip(userQueryParam.Offset.Value);
+
+            if (userQueryParam.Limit.HasValue)
+                matchingUsers = matchingUsers.Take(userQueryParam.Limit.Value);
 
             try
             {

--- a/LBHFSSPortalAPI/V1/UseCase/CreateServiceUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/CreateServiceUseCase.cs
@@ -1,5 +1,6 @@
 using LBHFSSPortalAPI.V1.Boundary.Requests;
 using LBHFSSPortalAPI.V1.Boundary.Response;
+using LBHFSSPortalAPI.V1.Exceptions;
 using LBHFSSPortalAPI.V1.Factories;
 using LBHFSSPortalAPI.V1.Gateways.Interfaces;
 using LBHFSSPortalAPI.V1.UseCase.Interfaces;
@@ -18,15 +19,15 @@ namespace LBHFSSPortalAPI.V1.UseCase
 
         public async Task<ServiceResponse> Execute(ServiceRequest request)
         {
-            Validate(request);
             var serviceDomain = await _servicesGateway.CreateService(request).ConfigureAwait(false);
 
-            return serviceDomain.ToResponse();
-        }
+            if (serviceDomain == null)
+                throw new UseCaseException()
+                {
+                    UserErrorMessage = $"Could not create the new service.",
+                };
 
-        private void Validate(ServiceRequest request)
-        {
-            // all fine for now :)
+            return serviceDomain.ToResponse();
         }
     }
 }

--- a/LBHFSSPortalAPI/V1/UseCase/GetServicesUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/GetServicesUseCase.cs
@@ -20,15 +20,15 @@ namespace LBHFSSPortalAPI.V1.UseCase
 
         public async Task<ServiceResponse> Execute(int serviceId)
         {
-            var servicesDomain = await _servicesGateway.GetServiceAsync(serviceId).ConfigureAwait(false);
+            var serviceDomain = await _servicesGateway.GetServiceAsync(serviceId).ConfigureAwait(false);
 
-            if (servicesDomain == null)
+            if (serviceDomain == null)
                 throw new UseCaseException()
                 {
-                    UserErrorMessage = $"Could not retrieve service with an ID of '{serviceId}'",
+                    UserErrorMessage = $"Could not retrieve the service with an ID of '{serviceId}'",
                 };
 
-            return servicesDomain.ToResponse();
+            return serviceDomain.ToResponse();
         }
 
         public async Task<List<ServiceResponse>> Execute(ServicesQueryParam servicesQuery)

--- a/LBHFSSPortalAPI/V1/UseCase/UpdateServiceUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/UpdateServiceUseCase.cs
@@ -1,5 +1,6 @@
 using LBHFSSPortalAPI.V1.Boundary.Requests;
 using LBHFSSPortalAPI.V1.Boundary.Response;
+using LBHFSSPortalAPI.V1.Exceptions;
 using LBHFSSPortalAPI.V1.Factories;
 using LBHFSSPortalAPI.V1.Gateways.Interfaces;
 using LBHFSSPortalAPI.V1.UseCase.Interfaces;
@@ -18,15 +19,15 @@ namespace LBHFSSPortalAPI.V1.UseCase
 
         public async Task<ServiceResponse> Execute(ServiceRequest request, int serviceId)
         {
-            Validate(request);
             var serviceDomain = await _servicesGateway.UpdateService(request, serviceId).ConfigureAwait(false);
 
-            return serviceDomain.ToResponse();
-        }
+            if (serviceDomain == null)
+                throw new UseCaseException()
+                {
+                    UserErrorMessage = $"Could not update the service with ID '{serviceId}'",
+                };
 
-        private void Validate(ServiceRequest request)
-        {
-            // all fine for now :)
+            return serviceDomain.ToResponse();
         }
     }
 }


### PR DESCRIPTION
- Implemented logic to add and update categories/demographics when POST and PATCH /services endpoints are called.
- Also now stores/retrieves 'service_description' for category type taxonomies.
- Also bug fix to call Skip()/Take() in the correct order when retrieving multiple services.