### PR TITLE
Registration-confirmation-fix

### DIFF
--- a/LBHFSSPortalAPI/V1/Gateways/AuthenticateGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/AuthenticateGateway.cs
@@ -47,6 +47,28 @@ namespace LBHFSSPortalAPI.V1.Gateways
                 throw;
             }
         }
+
+        public void ResendVerification(ConfirmationResendRequest confirmationResendRequest)
+        {
+            AdminCreateUserRequest adminCreateUserRequest = new AdminCreateUserRequest
+            {
+                UserPoolId = _connectionInfo.UserPoolId,
+                Username = confirmationResendRequest.Email,
+                DesiredDeliveryMediums = new List<string> { "EMAIL" },
+                MessageAction = MessageActionType.RESEND
+            };
+            try
+            {
+                var response = _provider.AdminCreateUserAsync(adminCreateUserRequest).Result;
+            }
+            catch (Exception e)
+            {
+                LoggingHandler.LogError(e.Message);
+                LoggingHandler.LogError(e.StackTrace);
+                throw;
+            }
+        }
+
         public string CreateUser(UserCreateRequest createRequest)
         {
             SignUpRequest signUpRequest = new SignUpRequest
@@ -113,27 +135,6 @@ namespace LBHFSSPortalAPI.V1.Gateways
             try
             {
                 _provider.ResendConfirmationCodeAsync(resendConfirmationCodeRequest).Wait();
-            }
-            catch (Exception e)
-            {
-                LoggingHandler.LogError(e.Message);
-                LoggingHandler.LogError(e.StackTrace);
-                throw;
-            }
-        }
-
-        public void ResendVerification(ConfirmationResendRequest confirmationResendRequest)
-        {
-            AdminCreateUserRequest adminCreateUserRequest = new AdminCreateUserRequest
-            {
-                UserPoolId = _connectionInfo.UserPoolId,
-                Username = confirmationResendRequest.Email,
-                DesiredDeliveryMediums = new List<string> { "EMAIL" },
-                MessageAction = MessageActionType.RESEND
-            };
-            try
-            {
-                var response = _provider.AdminCreateUserAsync(adminCreateUserRequest).Result;
             }
             catch (Exception e)
             {

--- a/LBHFSSPortalAPI/V1/Gateways/AuthenticateGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/AuthenticateGateway.cs
@@ -105,6 +105,25 @@ namespace LBHFSSPortalAPI.V1.Gateways
 
         public void ResendConfirmation(ConfirmationResendRequest confirmationResendRequest)
         {
+            ResendConfirmationCodeRequest resendConfirmationCodeRequest = new ResendConfirmationCodeRequest()
+            {
+                ClientId = _connectionInfo.ClientId,
+                Username = confirmationResendRequest.Email
+            };
+            try
+            {
+                _provider.ResendConfirmationCodeAsync(resendConfirmationCodeRequest).Wait();
+            }
+            catch (Exception e)
+            {
+                LoggingHandler.LogError(e.Message);
+                LoggingHandler.LogError(e.StackTrace);
+                throw;
+            }
+        }
+
+        public void ResendVerification(ConfirmationResendRequest confirmationResendRequest)
+        {
             AdminCreateUserRequest adminCreateUserRequest = new AdminCreateUserRequest
             {
                 UserPoolId = _connectionInfo.UserPoolId,

--- a/LBHFSSPortalAPI/V1/Gateways/Interfaces/IAuthenticateGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/Interfaces/IAuthenticateGateway.cs
@@ -10,6 +10,7 @@ namespace LBHFSSPortalAPI.V1.Gateways.Interfaces
         bool ConfirmSignup(UserConfirmRequest confirmRequest);
         AuthenticationResult LoginUser(LoginUserQueryParam loginUserQueryParam);
         void ResendConfirmation(ConfirmationResendRequest confirmationResendRequest);
+        void ResendVerification(ConfirmationResendRequest confirmationResendRequest);
         void ResetPassword(ResetPasswordQueryParams resetPasswordQueryParams);
         void ConfirmResetPassword(ResetPasswordQueryParams resetPasswordQueryParams);
         void AdminChangePassword(ResetPasswordQueryParams resetPasswordQueryParams);

--- a/LBHFSSPortalAPI/V1/UseCase/ConfirmUserUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/ConfirmUserUseCase.cs
@@ -77,7 +77,7 @@ namespace LBHFSSPortalAPI.V1.UseCase
                     UserErrorMessage = $"A user with the supplied ID of '{userId}' could not be found"
                 };
 
-            _authenticateGateway.ResendConfirmation(new ConfirmationResendRequest { Email = userDomain.Email });
+            _authenticateGateway.ResendVerification(new ConfirmationResendRequest { Email = userDomain.Email });
         }
     }
 }


### PR DESCRIPTION
## What
Implemented a separate process for registration confirmations

## Why
The process for confirming a registered user and verifying a user created by an admin are different.  The methods for verifying needed to be created separately as the registration confirmation will not work for a user that was created by an admin.