### PR TITLE
Add personalisation status message to notify api call

### DIFF
--- a/LBHFSSPortalAPI.Tests/V1/Boundary/Requests/OrganisationRequestTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/Boundary/Requests/OrganisationRequestTests.cs
@@ -14,7 +14,7 @@ namespace LBHFSSPortalAPI.Tests.V1.Boundary.Requests
         public void GetServiceResponseObjectShouldHaveCorrectProperties()
         {
             var entityType = typeof(OrganisationRequest);
-            entityType.GetProperties().Length.Should().Be(32);
+            entityType.GetProperties().Length.Should().Be(33);
             var entity = Randomm.Create<OrganisationRequest>();
             Assert.That(entity, Has.Property("Name").InstanceOf(typeof(string)));
             Assert.That(entity, Has.Property("CreatedAt").InstanceOf(typeof(DateTime)));
@@ -23,6 +23,7 @@ namespace LBHFSSPortalAPI.Tests.V1.Boundary.Requests
             Assert.That(entity, Has.Property("ReviewedAt").InstanceOf(typeof(DateTime)));
             Assert.That(entity, Has.Property("ReviewerMessage").InstanceOf(typeof(string)));
             Assert.That(entity, Has.Property("Status").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("StatusMessage").InstanceOf(typeof(string)));
             Assert.That(entity, Has.Property("IsHackneyBased").InstanceOf(typeof(bool)));
             Assert.That(entity, Has.Property("IsRegisteredCharity").InstanceOf(typeof(bool)));
             Assert.That(entity, Has.Property("CharityNumber").InstanceOf(typeof(string)));

--- a/LBHFSSPortalAPI.Tests/V1/Boundary/Responses/OrganisationResponseTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/Boundary/Responses/OrganisationResponseTests.cs
@@ -14,7 +14,7 @@ namespace LBHFSSPortalAPI.Tests.V1.Boundary.Requests
         public void GetServiceResponseObjectShouldHaveCorrectProperties()
         {
             var entityType = typeof(OrganisationResponse);
-            entityType.GetProperties().Length.Should().Be(33);
+            entityType.GetProperties().Length.Should().Be(34);
             var entity = Randomm.Create<OrganisationResponse>();
             Assert.That(entity, Has.Property("Id").InstanceOf(typeof(int)));
             Assert.That(entity, Has.Property("Name").InstanceOf(typeof(string)));
@@ -24,6 +24,7 @@ namespace LBHFSSPortalAPI.Tests.V1.Boundary.Requests
             Assert.That(entity, Has.Property("ReviewedAt").InstanceOf(typeof(DateTime)));
             Assert.That(entity, Has.Property("ReviewerMessage").InstanceOf(typeof(string)));
             Assert.That(entity, Has.Property("Status").InstanceOf(typeof(string)));
+            Assert.That(entity, Has.Property("StatusMessage").InstanceOf(typeof(string)));
             Assert.That(entity, Has.Property("IsHackneyBased").InstanceOf(typeof(bool)));
             Assert.That(entity, Has.Property("IsRegisteredCharity").InstanceOf(typeof(bool)));
             Assert.That(entity, Has.Property("CharityNumber").InstanceOf(typeof(string)));

--- a/LBHFSSPortalAPI.Tests/V1/Gateways/OrganisationsGatewayTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/Gateways/OrganisationsGatewayTests.cs
@@ -83,6 +83,7 @@ namespace LBHFSSPortalAPI.Tests.V1.Gateways
                 options.Excluding(ex => ex.ReviewerU);
                 options.Excluding(ex => ex.Services);
                 options.Excluding(ex => ex.UserOrganisations);
+                options.Excluding(ex => ex.StatusMessage);
                 return options;
             });
         }

--- a/LBHFSSPortalAPI/V1/Boundary/Requests/OrganisationRequest.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Requests/OrganisationRequest.cs
@@ -17,6 +17,8 @@ namespace LBHFSSPortalAPI.V1.Boundary.Requests
         [JsonPropertyName("reviewer_message")]
         public string ReviewerMessage { get; set; }
         public string Status { get; set; }
+        [JsonPropertyName("status_message")]
+        public string StatusMessage { get; set; }
         [JsonPropertyName("is_hackney_based")]
         public bool? IsHackneyBased { get; set; }
         [JsonPropertyName("is_registered_charity")]

--- a/LBHFSSPortalAPI/V1/Boundary/Response/OrganisationResponse.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Response/OrganisationResponse.cs
@@ -18,6 +18,8 @@ namespace LBHFSSPortalAPI.V1.Boundary.Response
         [JsonPropertyName("reviewer_message")]
         public string ReviewerMessage { get; set; }
         public string Status { get; set; }
+        [JsonPropertyName("status_message")]
+        public string StatusMessage { get; set; }
         [JsonPropertyName("is_hackney_based")]
         public bool? IsHackneyBased { get; set; }
         [JsonPropertyName("is_registered_charity")]

--- a/LBHFSSPortalAPI/V1/Domain/OrganisationDomain.cs
+++ b/LBHFSSPortalAPI/V1/Domain/OrganisationDomain.cs
@@ -20,6 +20,7 @@ namespace LBHFSSPortalAPI.V1.Domain
         public DateTime? ReviewedAt { get; set; }
         public string ReviewerMessage { get; set; }
         public string Status { get; set; }
+        public string StatusMessage { get; set; }
         public bool? IsHackneyBased { get; set; }
         public bool? IsRegisteredCharity { get; set; }
         public string CharityNumber { get; set; }

--- a/LBHFSSPortalAPI/V1/Factories/MappingHelper.cs
+++ b/LBHFSSPortalAPI/V1/Factories/MappingHelper.cs
@@ -21,7 +21,8 @@ namespace LBHFSSPortalAPI.V1.Factories
                 cfg.CreateMap<Service, ServiceDomain>();
                 cfg.CreateMap<File, FileDomain>();
                 cfg.CreateMap<UserOrganisation, UserOrganisationDomain>();
-                cfg.CreateMap<Organisation, OrganisationDomain>();
+                cfg.CreateMap<Organisation, OrganisationDomain>()
+                    .ForMember(x => x.StatusMessage, opt => opt.Ignore());
                 cfg.CreateMap<Taxonomy, TaxonomyDomain>();
                 cfg.CreateMap<ServiceLocation, ServiceLocationDomain>();
                 cfg.CreateMap<ServiceTaxonomy, ServiceTaxonomyDomain>();

--- a/LBHFSSPortalAPI/V1/Gateways/Interfaces/INotifyGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/Interfaces/INotifyGateway.cs
@@ -5,6 +5,6 @@ namespace LBHFSSPortalAPI.V1.Gateways.Interfaces
 {
     public interface INotifyGateway
     {
-        Task SendMessage(NotifyMessageTypes messageType, string[] addresses);
+        Task SendMessage(NotifyMessageTypes messageType, string[] addresses, string message);
     }
 }

--- a/LBHFSSPortalAPI/V1/UseCase/OrganisationsUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/OrganisationsUseCase.cs
@@ -41,7 +41,7 @@ namespace LBHFSSPortalAPI.V1.UseCase
                 var adminUsers = _usersGateway.GetAllUsers(userQueryParam).Result
                     .Where(u => u.UserRoles.Any(ur => ur.Role.Name == "Admin"));
                 var adminEmails = adminUsers.Select(au => au.Email).ToArray();
-                _notifyGateway.SendMessage(NotifyMessageTypes.AdminNotification, adminEmails);
+                _notifyGateway.SendMessage(NotifyMessageTypes.AdminNotification, adminEmails, requestParams.StatusMessage);
             }
             return gatewayResponse == null ? new OrganisationResponse() : gatewayResponse.ToResponse();
         }
@@ -101,13 +101,13 @@ namespace LBHFSSPortalAPI.V1.UseCase
             {
                 var orgUserEmails = gatewayResponse.UserOrganisations
                     .Select(uo => uo.User.Email).ToArray();
-                _notifyGateway.SendMessage(NotifyMessageTypes.StatusUpdate, orgUserEmails);
+                _notifyGateway.SendMessage(NotifyMessageTypes.StatusUpdate, orgUserEmails, request.StatusMessage);
             }
             if (gatewayResponse != null && gatewayResponse.Status.ToLower() == "rejected")
             {
                 var orgUserEmails = gatewayResponse.UserOrganisations
                     .Select(uo => uo.User.Email).ToArray();
-                _notifyGateway.SendMessage(NotifyMessageTypes.NotApproved, orgUserEmails);
+                _notifyGateway.SendMessage(NotifyMessageTypes.NotApproved, orgUserEmails, request.StatusMessage);
             }
             if (gatewayResponse != null && gatewayResponse.Status.ToLower() == "awaiting review")
             {
@@ -115,7 +115,7 @@ namespace LBHFSSPortalAPI.V1.UseCase
                 var adminUsers = _usersGateway.GetAllUsers(userQueryParam).Result
                     .Where(u => u.UserRoles.Any(ur => ur.Role.Name == "Admin"));
                 var adminEmails = adminUsers.Select(au => au.Email).ToArray();
-                _notifyGateway.SendMessage(NotifyMessageTypes.AdminNotification, adminEmails);
+                _notifyGateway.SendMessage(NotifyMessageTypes.AdminNotification, adminEmails, request.StatusMessage);
             }
             return gatewayResponse.ToResponse();
         }


### PR DESCRIPTION
### What is the problem we're trying to solve
Admins need to be able to add custom message to the emails sent to organisation users if ever a review has been rejected.

### What changes have we introduced

Update to the notify gateway to add a personalisation parameter to the not_approved template before calling the gov notify api

Checklist
 

- [x] Added tests to cover all new production code

- [x]  Checked all code for possible refactoring

- [x] Code pipeline builds correctly