### PR TITLE
Set session expiry and fix tests

### DIFF
--- a/LBHFSSPortalAPI.Tests/IntegrationTests.cs
+++ b/LBHFSSPortalAPI.Tests/IntegrationTests.cs
@@ -41,7 +41,14 @@ namespace LBHFSSPortalAPI.Tests
             Client = _factory.CreateClient();
             DatabaseContext = new DatabaseContext(_builder.Options);
             DatabaseContext.Database.EnsureCreated();
-            _transaction = DatabaseContext.Database.BeginTransaction();
+            try
+            {
+                _transaction = DatabaseContext.Database.BeginTransaction();
+            }
+            catch (InvalidOperationException e)
+            {
+                Console.WriteLine($"transaction rollback failed: {e}");
+            }
         }
 
         [TearDown]

--- a/LBHFSSPortalAPI.Tests/TestHelpers/EntityHelpers.cs
+++ b/LBHFSSPortalAPI.Tests/TestHelpers/EntityHelpers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -106,6 +107,7 @@ namespace LBHFSSPortalAPI.Tests.TestHelpers
                 .Without(o => o.Id)
                 .With(o => o.User, user)
                 .Create();
+            session.LastAccessAt = DateTime.Now;
             return session;
         }
 

--- a/LBHFSSPortalAPI.Tests/V1/E2ETests/DeleteOrganisationTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/E2ETests/DeleteOrganisationTests.cs
@@ -17,10 +17,17 @@ namespace LBHFSSPortalAPI.Tests.V1.E2ETests
     [TestFixture]
     public class DeleteOrganisationsTests : IntegrationTests<Startup>
     {
-        //[TestCase(TestName = "Given an id provided, a delete success response is returned")]
+        [SetUp]
+        public void SetUp()
+        {
+            CustomizeAssertions.ApproximationDateTime();
+            DatabaseContext.Database.RollbackTransaction();
+            E2ETestHelpers.ClearTable(DatabaseContext);
+        }
+
+        [TestCase(TestName = "Given an id provided, a delete success response is returned")]
         public async Task DeleteOrganisationReturnsSuccess()
         {
-            DatabaseContext.Database.RollbackTransaction();
             var session = EntityHelpers.CreateSession("Admin");
             DatabaseContext.Sessions.Add(session);
             Client.DefaultRequestHeaders.Add("Cookie", $"access_token={session.Payload}");
@@ -34,7 +41,6 @@ namespace LBHFSSPortalAPI.Tests.V1.E2ETests
             var stringResponse = await content.ReadAsStringAsync().ConfigureAwait(true);
             var deserializedBody = JsonConvert.DeserializeObject<OrganisationResponse>(stringResponse);
             deserializedBody.Should().BeNull();
-            DatabaseContext.Database.BeginTransaction();
         }
     }
 }

--- a/LBHFSSPortalAPI.Tests/V1/E2ETests/E2ETestHelpers.cs
+++ b/LBHFSSPortalAPI.Tests/V1/E2ETests/E2ETestHelpers.cs
@@ -1,0 +1,17 @@
+using AutoFixture;
+using LBHFSSPortalAPI.V1.Infrastructure;
+
+namespace LBHFSSPortalAPI.Tests.V1.E2ETests
+{
+    public static class E2ETestHelpers
+    {
+        public static void ClearTable(DatabaseContext context)
+        {
+            var addedOrganisations = context.Organisations;
+            context.Organisations.RemoveRange(addedOrganisations);
+            var addedSessions = context.Sessions;
+            context.Sessions.RemoveRange(addedSessions);
+            context.SaveChanges();
+        }
+    }
+}

--- a/LBHFSSPortalAPI.Tests/V1/E2ETests/GetOrganisationsTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/E2ETests/GetOrganisationsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,10 +16,17 @@ namespace LBHFSSPortalAPI.Tests.V1.E2ETests
     [TestFixture]
     public class GetOrganisationsTests : IntegrationTests<Startup>
     {
-        //[TestCase(TestName = "Given an id provided, an organisation with the matching id is returned")]
+        [SetUp]
+        public void SetUp()
+        {
+            CustomizeAssertions.ApproximationDateTime();
+            DatabaseContext.Database.RollbackTransaction();
+            E2ETestHelpers.ClearTable(DatabaseContext);
+        }
+
+        [TestCase(TestName = "Given an id provided, an organisation with the matching id is returned")]
         public async Task GetOrganisationByIdReturnsOrganisation()
         {
-            DatabaseContext.Database.RollbackTransaction();
             var session = EntityHelpers.CreateSession("Admin");
             DatabaseContext.Sessions.Add(session);
             Client.DefaultRequestHeaders.Add("Cookie", $"access_token={session.Payload}");
@@ -32,8 +40,23 @@ namespace LBHFSSPortalAPI.Tests.V1.E2ETests
             var stringResponse = await content.ReadAsStringAsync().ConfigureAwait(true);
             var deserializedBody = JsonConvert.DeserializeObject<OrganisationResponse>(stringResponse);
             deserializedBody.Should().NotBeNull();
-            //deserializedBody.Should().BeEquivalentTo(organisation);
-            DatabaseContext.Database.BeginTransaction();
+        }
+
+        [TestCase(TestName =
+            "Given a session token is provided for an expired session, a not authorised response should be returned")]
+        public async Task GetOrganisationWithExpiredSessionReturnsNotAuthorised()
+        {
+            var session = EntityHelpers.CreateSession("Admin");
+            session.LastAccessAt = DateTime.Today.AddDays(-2);
+            DatabaseContext.Sessions.Add(session);
+            Client.DefaultRequestHeaders.Add("Cookie", $"access_token={session.Payload}");
+            var organisation = EntityHelpers.CreateOrganisation();
+            DatabaseContext.Organisations.Add(organisation);
+            DatabaseContext.SaveChanges();
+            var requestUri = new Uri($"api/v1/organisations/{organisation.Id}", UriKind.Relative);
+            var response = await Client.GetAsync(requestUri).ConfigureAwait(false);
+            response.StatusCode.Should().Be(401);
+            DatabaseContext.Sessions.Count(s => s.UserId == session.UserId).Should().Be(0);
         }
     }
 }

--- a/LBHFSSPortalAPI.Tests/V1/E2ETests/PatchOrganisationTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/E2ETests/PatchOrganisationTests.cs
@@ -15,10 +15,17 @@ namespace LBHFSSPortalAPI.Tests.V1.E2ETests
     [TestFixture]
     public class PatchOrganisationTests : IntegrationTests<Startup>
     {
-        //[TestCase(TestName = "Given that valid parameters are provided, the specified organisation is updated in the database")]
+        [SetUp]
+        public void SetUp()
+        {
+            CustomizeAssertions.ApproximationDateTime();
+            DatabaseContext.Database.RollbackTransaction();
+            E2ETestHelpers.ClearTable(DatabaseContext);
+        }
+
+        [TestCase(TestName = "Given that valid parameters are provided, the specified organisation is updated in the database")]
         public async Task PatchOrganisationUpdatesOrganisation()
         {
-            DatabaseContext.Database.RollbackTransaction();
             var session = EntityHelpers.CreateSession("Admin");
             DatabaseContext.Sessions.Add(session);
             Client.DefaultRequestHeaders.Add("Cookie", $"access_token={session.Payload}");
@@ -42,7 +49,6 @@ namespace LBHFSSPortalAPI.Tests.V1.E2ETests
             dbOrganisation.Should().NotBeNull();
             dbOrganisation.Name.Should().Be(organisation.Name);
             dbOrganisation.ReviewerMessage.Should().Be(organisation.ReviewerMessage);  //should not be set to null if not changed
-            DatabaseContext.Database.BeginTransaction();
         }
     }
 }

--- a/LBHFSSPortalAPI.Tests/V1/E2ETests/PostOrganisationTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/E2ETests/PostOrganisationTests.cs
@@ -15,10 +15,17 @@ namespace LBHFSSPortalAPI.Tests.V1.E2ETests
     [TestFixture]
     public class PostOrganisationTests : IntegrationTests<Startup>
     {
+        [SetUp]
+        public void SetUp()
+        {
+            CustomizeAssertions.ApproximationDateTime();
+            DatabaseContext.Database.RollbackTransaction();
+            E2ETestHelpers.ClearTable(DatabaseContext);
+        }
+
         //[TestCase(TestName = "Given that valid parameters are provided, organisations are added to the database")]
         public async Task PostOrganisationCreatesOrganisation()
         {
-            DatabaseContext.Database.RollbackTransaction();
             var session = EntityHelpers.CreateSession("Admin");
             DatabaseContext.Sessions.Add(session);
             Client.DefaultRequestHeaders.Add("Cookie", $"access_token={session.Payload}");
@@ -36,7 +43,6 @@ namespace LBHFSSPortalAPI.Tests.V1.E2ETests
             var organisationId = deserializedBody.Id;
             var dbOrganisation = DatabaseContext.Organisations.Find(organisationId);
             dbOrganisation.Should().NotBeNull();
-            DatabaseContext.Database.BeginTransaction();
         }
     }
 }

--- a/LBHFSSPortalAPI.Tests/V1/E2ETests/SearchOrganisationsTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/E2ETests/SearchOrganisationsTests.cs
@@ -17,10 +17,17 @@ namespace LBHFSSPortalAPI.Tests.V1.E2ETests
     [TestFixture]
     public class SearchOrganisationsTests : IntegrationTests<Startup>
     {
-        //[TestCase(TestName = "Given valid search parameters provided, organisations that match are returned")]
+        [SetUp]
+        public void SetUp()
+        {
+            CustomizeAssertions.ApproximationDateTime();
+            DatabaseContext.Database.RollbackTransaction();
+            E2ETestHelpers.ClearTable(DatabaseContext);
+        }
+
+        [TestCase(TestName = "Given valid search parameters provided, organisations that match are returned")]
         public async Task SearchOrganisationBySearchParamsReturnsOrganisations()
         {
-            DatabaseContext.Database.RollbackTransaction();
             var session = EntityHelpers.CreateSession("Admin");
             DatabaseContext.Sessions.Add(session);
             Client.DefaultRequestHeaders.Add("Cookie", $"access_token={session.Payload}");
@@ -38,10 +45,9 @@ namespace LBHFSSPortalAPI.Tests.V1.E2ETests
             deserializedBody.Organisations.First().Name.Should().BeEquivalentTo(organisations.First().Name);
         }
 
-        //[TestCase(TestName = "Given valid search parameters and a specified sort order, organisations that match are returned in the order specified")]
+        [TestCase(TestName = "Given valid search parameters and a specified sort order, organisations that match are returned in the order specified")]
         public async Task SearchOrganisationBySearchParamsReturnsOrganisationsInTheSortOrderSpecified()
         {
-            DatabaseContext.Database.RollbackTransaction();
             var session = EntityHelpers.CreateSession("Admin");
             DatabaseContext.Sessions.Add(session);
             Client.DefaultRequestHeaders.Add("Cookie", $"access_token={session.Payload}");
@@ -63,7 +69,6 @@ namespace LBHFSSPortalAPI.Tests.V1.E2ETests
             deserializedBody.Should().NotBeNull();
             deserializedBody.Organisations[0].Name.Should().BeEquivalentTo(organisations[5].Name);
             deserializedBody.Organisations[1].Name.Should().BeEquivalentTo(organisations[3].Name);
-            DatabaseContext.Database.BeginTransaction();
         }
     }
 }

--- a/LBHFSSPortalAPI.Tests/V1/Gateways/SessionsGateway.cs
+++ b/LBHFSSPortalAPI.Tests/V1/Gateways/SessionsGateway.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Linq;
+using AutoMapper;
+using FluentAssertions;
+using LBHFSSPortalAPI.Tests.TestHelpers;
+using LBHFSSPortalAPI.V1.Boundary.Requests;
+using LBHFSSPortalAPI.V1.Domain;
+using LBHFSSPortalAPI.V1.Factories;
+using LBHFSSPortalAPI.V1.Gateways;
+using LBHFSSPortalAPI.V1.Infrastructure;
+using NUnit.Framework;
+
+namespace LBHFSSPortalAPI.Tests.V1.Gateways
+{
+    [TestFixture]
+    public class SessionsGatewayTests : DatabaseTests
+    {
+        private SessionsGateway _classUnderTest;
+
+        [SetUp]
+        public void Setup()
+        {
+            _classUnderTest = new SessionsGateway(DatabaseContext);
+        }
+
+        [TestCase(TestName = "Given a session in the database, when the session id is provided the session data is returned")]
+        public void GivenValidSessionInDatabaseSessionGetsReturned()
+        {
+            var session = EntityHelpers.CreateSession("VCSO");
+            DatabaseContext.Sessions.Add(session);
+            DatabaseContext.SaveChanges();
+            var gatewayResult = _classUnderTest.GetSessionByToken(session.Payload);
+            gatewayResult.Should().NotBeNull();
+            gatewayResult.Should().BeEquivalentTo(session);
+        }
+
+        [TestCase(TestName = "Given a session in the database, when the refresh session is called the last access date is updated")]
+        public void GivenValidSessionInDatabaseRefreshSessionUpdatesLastAccessAt()
+        {
+            var session = EntityHelpers.CreateSession("VCSO");
+            DatabaseContext.Sessions.Add(session);
+            DatabaseContext.SaveChanges();
+            _classUnderTest.RefreshSessionExpiry(session.Id);
+            var updatedSession = DatabaseContext.Sessions.Find(session.Id);
+            updatedSession.LastAccessAt.Should().BeCloseTo(DateTime.Now);
+        }
+    }
+}

--- a/LBHFSSPortalAPI/Startup.cs
+++ b/LBHFSSPortalAPI/Startup.cs
@@ -155,7 +155,7 @@ namespace LBHFSSPortalAPI
                 NotifyKey = Environment.GetEnvironmentVariable("NOTIFY_KEY")
             };
             services.AddTransient<IAuthenticateGateway>(x => new AuthenticateGateway(connInfo));
-            services.AddTransient<INotifyGateway>(x => connInfo.NotifyKey == null? null : new NotifyGateway(connInfo));
+            services.AddTransient<INotifyGateway>(x => connInfo.NotifyKey == null ? null : new NotifyGateway(connInfo));
             services.AddTransient<IRepositoryGateway>(x => new RepositoryGateway(connInfo));
             services.AddScoped<IUsersGateway, UsersGateway>();
             services.AddScoped<ISessionsGateway, SessionsGateway>();

--- a/LBHFSSPortalAPI/Startup.cs
+++ b/LBHFSSPortalAPI/Startup.cs
@@ -155,7 +155,7 @@ namespace LBHFSSPortalAPI
                 NotifyKey = Environment.GetEnvironmentVariable("NOTIFY_KEY")
             };
             services.AddTransient<IAuthenticateGateway>(x => new AuthenticateGateway(connInfo));
-            services.AddTransient<INotifyGateway>(x => new NotifyGateway(connInfo));
+            services.AddTransient<INotifyGateway>(x => connInfo.NotifyKey == null? null : new NotifyGateway(connInfo));
             services.AddTransient<IRepositoryGateway>(x => new RepositoryGateway(connInfo));
             services.AddScoped<IUsersGateway, UsersGateway>();
             services.AddScoped<ISessionsGateway, SessionsGateway>();
@@ -235,7 +235,8 @@ namespace LBHFSSPortalAPI
                 .AllowAnyMethod()
                 .AllowAnyHeader()
                 .AllowCredentials()
-                .WithOrigins(Environment.GetEnvironmentVariable("ALLOWED_ORIGINS").Split(',')));
+                .WithOrigins(Environment.GetEnvironmentVariable("ALLOWED_ORIGINS") == null ? "localhost".Split()
+                    : Environment.GetEnvironmentVariable("ALLOWED_ORIGINS").Split(',')));
             app.UseEndpoints(endpoints =>
         {
             // SwaggerGen won't find controllers that are routed via this technique.

--- a/LBHFSSPortalAPI/V1/Gateways/Interfaces/ISessionsGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/Interfaces/ISessionsGateway.cs
@@ -8,5 +8,6 @@ namespace LBHFSSPortalAPI.V1.Gateways.Interfaces
         void RemoveSessions(string accessToken);
         void RemoveSessions(int userId);
         Session GetSessionByToken(string token);
+        void RefreshSessionExpiry(int sessionId);
     }
 }

--- a/LBHFSSPortalAPI/V1/Gateways/OrganisationsGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/OrganisationsGateway.cs
@@ -27,7 +27,7 @@ namespace LBHFSSPortalAPI.V1.Gateways
             try
             {
                 Context.Organisations.Add(request);
-                Context.SaveChanges();
+                SaveChanges();
             }
             catch (Exception e)
             {
@@ -137,7 +137,7 @@ namespace LBHFSSPortalAPI.V1.Gateways
                 if (organisation == null)
                     throw new InvalidOperationException("Organisation does not exist");
                 Context.Organisations.Remove(organisation);
-                Context.SaveChanges();
+                SaveChanges();
             }
             catch (Exception e)
             {
@@ -186,7 +186,7 @@ namespace LBHFSSPortalAPI.V1.Gateways
                 org.IsLocalOfferListed = organisationDomain.IsLocalOfferListed;
                 org.ReviewerUid = organisationDomain.ReviewerUid;
                 Context.Organisations.Attach(org);
-                Context.SaveChanges();
+                SaveChanges();
                 return _mapper.ToDomain(org);
             }
             catch (DbUpdateException dbe)

--- a/LBHFSSPortalAPI/V1/Gateways/SessionsGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/SessionsGateway.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using LBHFSSPortalAPI.V1.Gateways.Interfaces;
 using LBHFSSPortalAPI.V1.Infrastructure;
@@ -29,6 +30,16 @@ namespace LBHFSSPortalAPI.V1.Gateways
                 .ThenInclude(uo => uo.Organisation)
                 .FirstOrDefault(s => s.Payload == token);
             return session;
+        }
+
+        public void RefreshSessionExpiry(int sessionId)
+        {
+            var session = Context.Sessions.Find(sessionId);
+            if (session != null)
+            {
+                session.LastAccessAt = DateTime.Now;
+                SaveChanges();
+            }
         }
 
         public void RemoveSessions(string accessToken)

--- a/LBHFSSPortalAPI/serverless.yml
+++ b/LBHFSSPortalAPI/serverless.yml
@@ -31,6 +31,7 @@ functions:
       ADDRESS_KEY: ${ssm:/fss-portal-api/${self:provider.stage}/address-key}
       ADDRESS_API_TOKEN: ${ssm:/fss-common-api/${self:provider.stage}/addresses-api-token}
       REPOSITORY_BUCKET: ${ssm:/fss-portal-api/${self:provider.stage}/repository-bucket}
+      SESSION_DURATION: ${ssm:/fss-portal-api/${self:provider.stage}/session-duration}
     events:
       - http:
           path: /{proxy+}


### PR DESCRIPTION
#What
- Set the user login session to expire after a specified period of time
- Add database setup and cleardown helper class to fix failing E2E tests

#Why
- At the moment when a user session is created it never expires which imposes a security risk on the user.  Adding the session expiry means the session will no longer be valid after a predetermined period of inactivity.
- There were some db concurrency issues with the E2E tests that caused them to fail.  Adding the helper class to ensure the database is prepared for the next test resolved this issue.

#Note
- Session duration is set as an environment variable (set in AWS SSM).  Defaults to 24 hours if no value is provided.