### PR TITLE
Bugfix vcso create link

### DIFF
--- a/LBHFSSPortalAPI.Tests/V1/UseCase/UserOrganisationUseCaseTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/UseCase/UserOrganisationUseCaseTests.cs
@@ -31,16 +31,26 @@ namespace LBHFSSPortalAPI.Tests.V1.UseCase
         [TestCase(TestName = "A call to the user organisation links use case create method calls the gateway create action")]
         public void CreateUserOrganisationLinksUseCaseCallsGatewayCreateUserOrganisationLink()
         {
+            UserClaims userClaims = new UserClaims
+            {
+                UserId = 1,
+                UserRole = "Admin"
+            };
             var requestParams = Randomm.Create<UserOrganisationRequest>();
             var domainData = Randomm.Create<UserOrganisationDomain>();
             _mockUserOrganisationLinksGateway.Setup(x => x.LinkUserToOrganisation(It.IsAny<int>(), It.IsAny<int>())).Returns(domainData);
-            _classUnderTest.ExecuteCreate(requestParams);
+            _classUnderTest.ExecuteCreate(requestParams, userClaims);
             _mockUserOrganisationLinksGateway.Verify(u => u.LinkUserToOrganisation(It.IsAny<int>(), It.IsAny<int>()), Times.Once);
         }
 
         [TestCase(TestName = "Given required request object is provided the created userorganisation is returned")]
         public void ReturnsCreatedUserOrganisation()
         {
+            UserClaims userClaims = new UserClaims
+            {
+                UserId = 1,
+                UserRole = "Admin"
+            };
             var domainData = Randomm.Create<UserOrganisationDomain>();
             var requestParams = new UserOrganisationRequest
             {
@@ -48,7 +58,7 @@ namespace LBHFSSPortalAPI.Tests.V1.UseCase
                 UserId = domainData.UserId
             };
             _mockUserOrganisationLinksGateway.Setup(x => x.LinkUserToOrganisation(requestParams.OrganisationId, requestParams.UserId)).Returns(domainData);
-            var response = _classUnderTest.ExecuteCreate(requestParams);
+            var response = _classUnderTest.ExecuteCreate(requestParams, userClaims);
             response.Should().NotBeNull();
             response.OrganisationId.Should().Be(requestParams.OrganisationId);
             response.UserId.Should().Be(requestParams.UserId);
@@ -57,6 +67,11 @@ namespace LBHFSSPortalAPI.Tests.V1.UseCase
         [TestCase(TestName = "Given required request object is provided for a link that already exists error is thrown.")]
         public void ChecksForExistingRecord()
         {
+            UserClaims userClaims = new UserClaims
+            {
+                UserId = 1,
+                UserRole = "Admin"
+            };
             var domainData = Randomm.Create<UserOrganisationDomain>();
             var requestParams = new UserOrganisationRequest
             {
@@ -64,7 +79,7 @@ namespace LBHFSSPortalAPI.Tests.V1.UseCase
                 UserId = domainData.UserId
             };
             _mockUserOrganisationLinksGateway.Setup(x => x.GetUserOrganisationByUserAndOrgId(requestParams.UserId, requestParams.OrganisationId)).Returns(domainData);
-            _classUnderTest.Invoking(c => c.ExecuteCreate(requestParams))
+            _classUnderTest.Invoking(c => c.ExecuteCreate(requestParams, userClaims))
                .Should()
                .Throw<Exception>();
         }

--- a/LBHFSSPortalAPI/V1/UseCase/Interfaces/IUserOrganisationUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/Interfaces/IUserOrganisationUseCase.cs
@@ -7,7 +7,7 @@ namespace LBHFSSPortalAPI.V1.UseCase.Interfaces
 {
     public interface IUserOrganisationUseCase
     {
-        UserOrganisationResponse ExecuteCreate(UserOrganisationRequest requestParams);
+        UserOrganisationResponse ExecuteCreate(UserOrganisationRequest requestParams, UserClaims userClaims);
         void ExecuteDelete(int userId);
     }
 }

--- a/LBHFSSPortalAPI/serverless.yml
+++ b/LBHFSSPortalAPI/serverless.yml
@@ -91,6 +91,8 @@ resources:
 custom:
   vpc:
     development:
+      securityGroupIds:
+        - sg-033babc9f5ce30345
       subnetIds:
         - subnet-0deabb5d8fb9c3446
         - subnet-000b89c249f12a8ad

--- a/LBHFSSPortalAPI/serverless.yml
+++ b/LBHFSSPortalAPI/serverless.yml
@@ -95,10 +95,14 @@ custom:
         - subnet-0deabb5d8fb9c3446
         - subnet-000b89c249f12a8ad
     staging:
+      securityGroupIds:
+        - sg-04c73000bf97eae7e
       subnetIds:
         - subnet-06d3de1bd9181b0d7
         - subnet-0ed7d7713d1127656
     production:
+      securityGroupIds:
+        - sg-060458cddaaa2742a 
       subnetIds:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34


### PR DESCRIPTION
Needed to be able to allow VCSO users to add links to their organisation.
However, we need to prevent a VCSO user from adding a link to an org for another user.
Admins can add links for anyone.