### PR TITLE
Add users list to Service and Organisation Responses

### DIFF
--- a/LBHFSSPortalAPI.Tests/V1/Boundary/Responses/OrganisationResponseTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/Boundary/Responses/OrganisationResponseTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using LBHFSSPortalAPI.Tests.TestHelpers;
 using LBHFSSPortalAPI.V1.Boundary.Response;
@@ -14,7 +15,7 @@ namespace LBHFSSPortalAPI.Tests.V1.Boundary.Requests
         public void GetServiceResponseObjectShouldHaveCorrectProperties()
         {
             var entityType = typeof(OrganisationResponse);
-            entityType.GetProperties().Length.Should().Be(34);
+            entityType.GetProperties().Length.Should().Be(35);
             var entity = Randomm.Create<OrganisationResponse>();
             Assert.That(entity, Has.Property("Id").InstanceOf(typeof(int)));
             Assert.That(entity, Has.Property("Name").InstanceOf(typeof(string)));
@@ -50,6 +51,7 @@ namespace LBHFSSPortalAPI.Tests.V1.Boundary.Requests
             Assert.That(entity, Has.Property("HasEnhancedSupport").InstanceOf(typeof(bool)));
             Assert.That(entity, Has.Property("IsLocalOfferListed").InstanceOf(typeof(bool)));
             Assert.That(entity, Has.Property("Reviewer").InstanceOf(typeof(OrganisationReviewer)));
+            Assert.That(entity, Has.Property("Users").InstanceOf(typeof(List<OrgUser>)));
         }
 
     }

--- a/LBHFSSPortalAPI/V1/Boundary/Response/OrganisationResponse.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Response/OrganisationResponse.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace LBHFSSPortalAPI.V1.Boundary.Response
@@ -70,11 +71,21 @@ namespace LBHFSSPortalAPI.V1.Boundary.Response
         public bool? IsLocalOfferListed { get; set; }
         [JsonPropertyName("reviewer")]
         public OrganisationReviewer Reviewer { get; set; }
+
+        public List<OrgUser> Users { get; set; }
     }
 
     public class OrganisationReviewer
     {
         public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class OrgUser
+    {
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+        [JsonPropertyName("name")]
         public string Name { get; set; }
     }
 }

--- a/LBHFSSPortalAPI/V1/Boundary/Response/ServiceResponse.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Response/ServiceResponse.cs
@@ -9,12 +9,6 @@ namespace LBHFSSPortalAPI.V1.Boundary.Response
         public int Id { get; set; }
         public string Name { get; set; }
 
-        [JsonPropertyName("user_id")]
-        public int? UserId { get; set; }
-
-        [JsonPropertyName("user_name")]
-        public string UserName { get; set; }
-
         [JsonPropertyName("organisation_id")]
         public int? OrganisationId { get; set; }
 
@@ -49,5 +43,6 @@ namespace LBHFSSPortalAPI.V1.Boundary.Response
         public List<LocationResponse> Locations { get; set; }
         public List<TaxonomyResponse> Categories { get; set; }
         public List<TaxonomyResponse> Demographics { get; set; }
+        public List<OrgUser> Users { get; set; }
     }
 }

--- a/LBHFSSPortalAPI/V1/Factories/ResponseFactory.cs
+++ b/LBHFSSPortalAPI/V1/Factories/ResponseFactory.cs
@@ -84,7 +84,8 @@ namespace LBHFSSPortalAPI.V1.Factories
                 {
                     Id = domain.ReviewerU.Id,
                     Name = domain.ReviewerU.Name
-                }
+                },
+                Users = formatUsers(domain.UserOrganisations)
             };
         }
 
@@ -105,6 +106,16 @@ namespace LBHFSSPortalAPI.V1.Factories
                 CreatedAt = domain.CreatedAt
             };
             return response;
+        }
+
+        public static List<OrgUser> formatUsers(ICollection<UserOrganisationDomain> users)
+        {
+            var orgUsers = users == null ? null : users.Select(u => new OrgUser
+            {
+                Id = u.User.Id,
+                Name = u.User.Name
+            }).ToList();
+            return orgUsers;
         }
 
     }

--- a/LBHFSSPortalAPI/V1/Factories/ServiceResponseFactory.cs
+++ b/LBHFSSPortalAPI/V1/Factories/ServiceResponseFactory.cs
@@ -18,8 +18,7 @@ namespace LBHFSSPortalAPI.V1.Factories
                 {
                     Id = domain.Id,
                     Name = domain.Name,
-                    UserId = user?.Id,
-                    UserName = user?.Name,
+                    Users = ResponseFactory.formatUsers(domain.Organisation.UserOrganisations),
                     OrganisationId = org?.Id,
                     OrganisationName = org?.Name,
                     Status = domain.Status,

--- a/LBHFSSPortalAPI/V1/Gateways/OrganisationsGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/OrganisationsGateway.cs
@@ -108,6 +108,8 @@ namespace LBHFSSPortalAPI.V1.Gateways
             {
                 var organisationList = await matchingOrganisations
                     .Include(o => o.ReviewerU)
+                    .Include(o => o.UserOrganisations)
+                    .ThenInclude(uo => uo.User)
                     .AsNoTracking()
                     .ToListAsync()
                     .ConfigureAwait(false);

--- a/LBHFSSPortalAPI/V1/UseCase/OrganisationsUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/OrganisationsUseCase.cs
@@ -99,13 +99,13 @@ namespace LBHFSSPortalAPI.V1.UseCase
             {
                 var orgUserEmails = gatewayResponse.UserOrganisations
                     .Select(uo => uo.User.Email).ToArray();
-                _notifyGateway.SendMessage(NotifyMessageTypes.StatusUpdate, orgUserEmails, request.StatusMessage);
+                _notifyGateway.SendMessage(NotifyMessageTypes.StatusUpdate, orgUserEmails, request.ReviewerMessage);
             }
             if (gatewayResponse != null && gatewayResponse.Status.ToLower() == "rejected")
             {
                 var orgUserEmails = gatewayResponse.UserOrganisations
                     .Select(uo => uo.User.Email).ToArray();
-                _notifyGateway.SendMessage(NotifyMessageTypes.NotApproved, orgUserEmails, request.StatusMessage);
+                _notifyGateway.SendMessage(NotifyMessageTypes.NotApproved, orgUserEmails, request.ReviewerMessage);
             }
             if (gatewayResponse != null && gatewayResponse.Status.ToLower() == "awaiting review")
             {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     image: postgres:12
     volumes:
       - ./database:/docker-entrypoint-initdb.d
+    ports:
+      - 6541:5432
 
   lbh-fss-portal-api-test:
     image: lbh-fss-portal-api-test


### PR DESCRIPTION
# What
- Return a list of users for the GET services, GET services/{id}, GET organisations and GET organisations/{id} responses

# Why
- These endpoints are now expected to return a list of users rather than an individual user