### PR TITLE
Service category description fix

### DIFF
--- a/LBHFSSPortalAPI/V1/Factories/ServiceResponseFactory.cs
+++ b/LBHFSSPortalAPI/V1/Factories/ServiceResponseFactory.cs
@@ -66,7 +66,7 @@ namespace LBHFSSPortalAPI.V1.Factories
                         {
                             Id = t.Taxonomy.Id,
                             Name = t.Taxonomy.Name,
-                            Description = t.Taxonomy.Description,
+                            Description = t.Description,
                             Vocabulary = t.Taxonomy.Vocabulary,
                             VocabularyId = 1,
                             Weight = t.Taxonomy.Weight


### PR DESCRIPTION
# What
- updated location where category description comes from

# Why
- updated category descriptions do not show on the portal since the data isn't returned from where it is expected.