### PR TITLE
Bugfix taxonomies response

### DIFF
--- a/LBHFSSPortalAPI/V1/Boundary/Response/TaxonomyResponse.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Response/TaxonomyResponse.cs
@@ -9,6 +9,7 @@ namespace LBHFSSPortalAPI.V1.Boundary.Response
         public string Name { get; set; }
         public string Description { get; set; }
         public string Vocabulary { get; set; }
+        [JsonPropertyName("vocabulary_id")]
         public int VocabularyId { get; set; }
         public int Weight { get; set; }
     }


### PR DESCRIPTION
Fixing issue where response field for vocabularyId was in a different format for request and response.

Changed response to be vocabulary_id to match the spec.