### PR TITLE
Feature add address paging

### DIFF
--- a/LBHFSSPortalAPI/V1/Gateways/AddressSearchGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/AddressSearchGateway.cs
@@ -35,7 +35,7 @@ namespace LBHFSSPortalAPI.V1.Gateways
                 var content = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
                 var addressDomain = JsonConvert.DeserializeObject<AddressAPIResponse>(content);
                 var addresses = addressDomain.Data.Addresses;
-                if(addressDomain.Data.PageCount > 1)
+                if (addressDomain.Data.PageCount > 1)
                 {
                     for (int i = 2; i <= addressDomain.Data.PageCount; i++)
                     {

--- a/LBHFSSPortalAPI/V1/Gateways/AddressSearchGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/AddressSearchGateway.cs
@@ -35,6 +35,20 @@ namespace LBHFSSPortalAPI.V1.Gateways
                 var content = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
                 var addressDomain = JsonConvert.DeserializeObject<AddressAPIResponse>(content);
                 var addresses = addressDomain.Data.Addresses;
+                if(addressDomain.Data.PageCount > 1)
+                {
+                    for (int i = 2; i <= addressDomain.Data.PageCount; i++)
+                    {
+                        response = await _client.GetAsync(new Uri($"addresses/?format=detailed&postcode={postCode}&page={i}", UriKind.Relative)).ConfigureAwait(true);
+                        if (!response.IsSuccessStatusCode)
+                        {
+                            throw new Exception(response.ReasonPhrase);
+                        }
+                        content = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+                        addressDomain = JsonConvert.DeserializeObject<AddressAPIResponse>(content);
+                        addresses = addresses.Concat(addressDomain.Data.Addresses).ToList();
+                    }
+                }
                 if (addresses != null)
                     return addresses;
                 return null;


### PR DESCRIPTION
### What
Address lookup now pages over all addresses returned by the address API and returns them

### Why
The addresses API returns a max of 50 results and allows paging but this hadn't been implemented so the users on the front end had no way of finding addresses beyond the first 50.