### PR TITLE
Bugfix delete taxonomy validation

### DIFF
--- a/LBHFSSPortalAPI.Tests/TestHelpers/EntityHelpers.cs
+++ b/LBHFSSPortalAPI.Tests/TestHelpers/EntityHelpers.cs
@@ -79,12 +79,14 @@ namespace LBHFSSPortalAPI.Tests.TestHelpers
             return organisation;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>")]
         public static ServiceLocation CreateServiceLocation()
         {
             var serviceLocation = Randomm.Build<ServiceLocation>()
                 .Without(sl => sl.Id)
                 .With(sl => sl.Latitude, (decimal) Randomm.Latitude())
                 .With(sl => sl.Longitude, (decimal) Randomm.Longitude())
+                .With(sl => sl.Uprn, Randomm.Uprn().ToString())
                 .With(sl => sl.Service, Randomm.Build<Service>()
                     .Without(s => s.Id)
                     .With(s => s.Organisation, CreateOrganisation())

--- a/LBHFSSPortalAPI.Tests/TestHelpers/Randomm.cs
+++ b/LBHFSSPortalAPI.Tests/TestHelpers/Randomm.cs
@@ -67,6 +67,11 @@ namespace LBHFSSPortalAPI.Tests.TestHelpers
         {
             return _faker.Random.Double(51.513, 51.58);
         }
+
+        public static long Uprn()
+        {
+            return _faker.Random.Long(100000000000, 299999999999);
+        }
     }
     #region Autofixture Customization
     public class IgnoreVirtualMembers : ISpecimenBuilder

--- a/LBHFSSPortalAPI.Tests/V1/Controllers/TaxonomiesControllerTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/Controllers/TaxonomiesControllerTests.cs
@@ -9,6 +9,7 @@ using LBHFSSPortalAPI.V1.Boundary.Requests;
 using LBHFSSPortalAPI.V1.Boundary.Response;
 using LBHFSSPortalAPI.V1.Controllers;
 using LBHFSSPortalAPI.V1.Domain;
+using LBHFSSPortalAPI.V1.Exceptions;
 using LBHFSSPortalAPI.V1.Factories;
 using LBHFSSPortalAPI.V1.Infrastructure;
 using LBHFSSPortalAPI.V1.UseCase.Interfaces;
@@ -174,6 +175,17 @@ namespace LBHFSSPortalAPI.Tests.V1.Controllers
             response.Should().NotBeNull();
             response.StatusCode.Should().Be(400);
         }
+
+        [TestCase(TestName = "When the taxonomy controller DeleteTaxonomy action is called with a taxonomy id which is still linked to a service, a 400 error response is returned")]
+        public void ExistingServiceTaxonomyLinksRespondsWith400Status()
+        {
+            var reqParam = Randomm.Create<int>();
+            _mockUseCase.Setup(u => u.ExecuteDelete(It.IsAny<int>())).Throws<ServiceTaxonomyExistsException>();
+            var response = _classUnderTest.DeleteTaxonomy(reqParam) as BadRequestObjectResult;
+            response.Should().NotBeNull();
+            response.StatusCode.Should().Be(400);
+        }
+
         #endregion
 
         #region Patch Taxonomy

--- a/LBHFSSPortalAPI.Tests/V1/Gateways/TaxonomyGatewayTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/Gateways/TaxonomyGatewayTests.cs
@@ -11,6 +11,7 @@ using LBHFSSPortalAPI.V1.Factories;
 using LBHFSSPortalAPI.V1.Gateways;
 using LBHFSSPortalAPI.V1.Infrastructure;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 
 namespace LBHFSSPortalAPI.Tests.V1.Gateways
 {
@@ -132,6 +133,24 @@ namespace LBHFSSPortalAPI.Tests.V1.Gateways
             gatewayResult.Should().BeEquivalentTo(expectedResult, options =>
             {
                 options.Excluding(ex => ex.ServiceTaxonomies);
+                return options;
+            });
+        }
+
+        [TestCase(TestName = "Given a taxonomy id when the gateway is called the gateway will return all matching Service Taxonomies")]
+        public void GivenATaxonomyIdMatchingServiceTaxonomiesAreReturned()
+        {
+            var service = EntityHelpers.CreateService();
+            DatabaseContext.Add(service);
+            DatabaseContext.SaveChanges();
+            var taxonomyId = service.ServiceTaxonomies.FirstOrDefault().TaxonomyId;
+            var gatewayResult = _classUnderTest.GetServiceTaxonomies(taxonomyId);
+            var expectedResult = DatabaseContext.ServiceTaxonomies.Where(x => x.TaxonomyId == taxonomyId);
+            gatewayResult.Should().NotBeNull();
+            gatewayResult.Should().BeEquivalentTo(expectedResult, options =>
+            {
+                options.Excluding(ex => ex.Service);
+                options.Excluding(ex => ex.Taxonomy.ServiceTaxonomies);
                 return options;
             });
         }

--- a/LBHFSSPortalAPI.Tests/V1/UseCase/TaxonomyUseCaseTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/UseCase/TaxonomyUseCaseTests.cs
@@ -129,7 +129,7 @@ namespace LBHFSSPortalAPI.Tests.V1.UseCase
         }
         #endregion
 
-        #region Delete Organisation
+        #region Delete Taxonomy
         [TestCase(TestName = "A call to the taxonomy use case delete method calls the gateway delete action")]
         public void DeleteTaxonomyUseCaseCallsGatewayDeleteTaxonomy()
         {

--- a/LBHFSSPortalAPI.Tests/V1/UseCase/TaxonomyUseCaseTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/UseCase/TaxonomyUseCaseTests.cs
@@ -2,10 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using FluentAssertions.Common;
 using LBHFSSPortalAPI.Tests.TestHelpers;
 using LBHFSSPortalAPI.V1.Boundary.Requests;
 using LBHFSSPortalAPI.V1.Boundary.Response;
 using LBHFSSPortalAPI.V1.Domain;
+using LBHFSSPortalAPI.V1.Exceptions;
 using LBHFSSPortalAPI.V1.Factories;
 using LBHFSSPortalAPI.V1.Gateways.Interfaces;
 using LBHFSSPortalAPI.V1.Infrastructure;
@@ -133,6 +135,8 @@ namespace LBHFSSPortalAPI.Tests.V1.UseCase
         [TestCase(TestName = "A call to the taxonomy use case delete method calls the gateway delete action")]
         public void DeleteTaxonomyUseCaseCallsGatewayDeleteTaxonomy()
         {
+            var serviceTaxonomies = new List<ServiceTaxonomyDomain>();
+            _mockTaxonomyGateway.Setup(g => g.GetServiceTaxonomies(It.IsAny<int>())).Returns(serviceTaxonomies);
             var id = Randomm.Create<int>();
             _classUnderTest.ExecuteDelete(id);
             _mockTaxonomyGateway.Verify(u => u.DeleteTaxonomy(It.IsAny<int>()), Times.Once);
@@ -142,6 +146,8 @@ namespace LBHFSSPortalAPI.Tests.V1.UseCase
         public void CallsGatewayDeleteAndDoesNotThrowErrorIfSuccessful()
         {
             var id = Randomm.Create<int>();
+            var serviceTaxonomies = new List<ServiceTaxonomyDomain>();
+            _mockTaxonomyGateway.Setup(g => g.GetServiceTaxonomies(It.IsAny<int>())).Returns(serviceTaxonomies);
             _mockTaxonomyGateway.Setup(g => g.DeleteTaxonomy(It.IsAny<int>()));
             _classUnderTest.Invoking(c => c.ExecuteDelete(id)).Should().NotThrow();
         }
@@ -150,9 +156,44 @@ namespace LBHFSSPortalAPI.Tests.V1.UseCase
         public void CallsGatewayDeleteAndThrowsErrorIfNotSuccessful()
         {
             var id = Randomm.Create<int>();
+            var serviceTaxonomies = new List<ServiceTaxonomyDomain>();
+            _mockTaxonomyGateway.Setup(g => g.GetServiceTaxonomies(It.IsAny<int>())).Returns(serviceTaxonomies);
             _mockTaxonomyGateway.Setup(g => g.DeleteTaxonomy(It.IsAny<int>())).Throws<InvalidOperationException>();
             _classUnderTest.Invoking(c => c.ExecuteDelete(id)).Should().Throw<InvalidOperationException>();
         }
+
+        [TestCase(TestName = "A call to the taxonomy use case delete method calls the gateway get servicetaxonomies action")]
+        public void DeleteTaxonomyUseCaseCallsGatewayGetServiceTaxonomies()
+        {
+            var id = Randomm.Create<int>();
+            var serviceTaxonomies = new List<ServiceTaxonomyDomain>();
+            _mockTaxonomyGateway.Setup(g => g.GetServiceTaxonomies(It.IsAny<int>())).Returns(serviceTaxonomies);
+            _classUnderTest.ExecuteDelete(id);
+            _mockTaxonomyGateway.Verify(u => u.GetServiceTaxonomies(It.IsAny<int>()), Times.Once);
+        }
+
+        [TestCase(TestName = "Given an taxonomy id is provided if matching servicetaxonomies exist then an exception is thrown")]
+        public void DeleteTaxonomyWhereTaxonomyStillLinkedToServiceThrowsError()
+        {
+            var id = Randomm.Create<int>();
+            var serviceTaxonomies = Randomm.CreateMany<ServiceTaxonomyDomain>().ToList();
+            _mockTaxonomyGateway.Setup(g => g.GetServiceTaxonomies(It.IsAny<int>())).Returns(serviceTaxonomies);
+            _classUnderTest.Invoking(c => c.ExecuteDelete(id)).Should().Throw<ServiceTaxonomyExistsException>();
+        }
+
+        [TestCase(TestName = "Given an taxonomy id is provided if matching servicetaxonomies exist then an exception is thrown and returns services")]
+        public void DeleteTaxonomyWhereTaxonomyStillLinkedToServiceThrowsErrorAndReturnsListOfServices()
+        {
+            var id = Randomm.Create<int>();
+            var serviceTaxonomies = Randomm.CreateMany<ServiceTaxonomyDomain>().ToList();
+            _mockTaxonomyGateway.Setup(g => g.GetServiceTaxonomies(It.IsAny<int>())).Returns(serviceTaxonomies);
+            _classUnderTest.Invoking(c => c.ExecuteDelete(id))
+                .Should()
+                .Throw<ServiceTaxonomyExistsException>()
+                .And
+                .Services.Count.IsSameOrEqualTo(serviceTaxonomies.Count);
+        }
+
         #endregion
 
         #region Patch Taxonomy

--- a/LBHFSSPortalAPI/V1/Boundary/Response/ServiceErrorResponse.cs
+++ b/LBHFSSPortalAPI/V1/Boundary/Response/ServiceErrorResponse.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace LBHFSSPortalAPI.V1.Boundary.Response
+{
+    public class ServiceErrorResponse
+    {
+        public string ErrorMessage { get; set; }
+        public List<ServiceError> Services { get; set; }
+    }
+
+    public class ServiceError
+    {
+        public int Id { get; set; }
+        public string ServiceName { get; set; }
+    }
+}

--- a/LBHFSSPortalAPI/V1/Controllers/TaxonomiesController.cs
+++ b/LBHFSSPortalAPI/V1/Controllers/TaxonomiesController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Security.Claims;
 using Amazon.Lambda.Core;
 using LBHFSSPortalAPI.V1.Boundary.Requests;
@@ -100,8 +101,6 @@ namespace LBHFSSPortalAPI.V1.Controllers
         [Route("{Id}")]
         public IActionResult DeleteTaxonomy([FromRoute] int id)
         {
-            //add validation
-
             try
             {
                 _taxonomyUseCase.ExecuteDelete(id);
@@ -117,6 +116,15 @@ namespace LBHFSSPortalAPI.V1.Controllers
             catch (UseCaseException e)
             {
                 return BadRequest(e);
+            }
+            catch (ServiceTaxonomyExistsException ex)
+            {
+                var errorResponse = new ServiceErrorResponse
+                {
+                    ErrorMessage = ex.DevErrorMessage,
+                    Services = ex.Services
+                };
+                return BadRequest(errorResponse);
             }
         }
     }

--- a/LBHFSSPortalAPI/V1/Exceptions/ServiceTaxonomyExistsException.cs
+++ b/LBHFSSPortalAPI/V1/Exceptions/ServiceTaxonomyExistsException.cs
@@ -1,10 +1,11 @@
 
+using LBHFSSPortalAPI.V1.Boundary.Response;
 using System.Collections.Generic;
 
 namespace LBHFSSPortalAPI.V1.Exceptions
 {
     public class ServiceTaxonomyExistsException : BaseException
     {
-        public Dictionary<int, string> Services { get; set; }
+        public List<ServiceError> Services { get; set; }
     }
 }

--- a/LBHFSSPortalAPI/V1/Exceptions/ServiceTaxonomyExistsException.cs
+++ b/LBHFSSPortalAPI/V1/Exceptions/ServiceTaxonomyExistsException.cs
@@ -1,0 +1,10 @@
+
+using System.Collections.Generic;
+
+namespace LBHFSSPortalAPI.V1.Exceptions
+{
+    public class ServiceTaxonomyExistsException : BaseException
+    {
+        public Dictionary<int, string> Services { get; set; }
+    }
+}

--- a/LBHFSSPortalAPI/V1/Gateways/Interfaces/ITaxonomyGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/Interfaces/ITaxonomyGateway.cs
@@ -15,5 +15,6 @@ namespace LBHFSSPortalAPI.V1.Gateways.Interfaces
         TaxonomyDomain PatchTaxonomy(int id, Taxonomy taxonomy);
         List<TaxonomyDomain> GetAllTaxonomies();
         List<TaxonomyDomain> GetTaxonomiesByVocabulary(string vocabulary);
+        List<ServiceTaxonomyDomain> GetServiceTaxonomies(int taxonomyId);
     }
 }

--- a/LBHFSSPortalAPI/V1/Gateways/TaxonomyGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/TaxonomyGateway.cs
@@ -133,5 +133,21 @@ namespace LBHFSSPortalAPI.V1.Gateways
                 throw;
             }
         }
+
+        public List<ServiceTaxonomyDomain> GetServiceTaxonomies(int taxonomyId)
+        {
+            try
+            {
+                var serviceTaxonomies = Context.ServiceTaxonomies
+                    .Where(x => x.TaxonomyId == taxonomyId);
+                return _mapper.ToDomain(serviceTaxonomies);
+            }
+            catch (Exception e)
+            {
+                LoggingHandler.LogError(e.Message);
+                LoggingHandler.LogError(e.StackTrace);
+                throw;
+            }
+        }
     }
 }

--- a/LBHFSSPortalAPI/V1/Gateways/TaxonomyGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/TaxonomyGateway.cs
@@ -139,7 +139,8 @@ namespace LBHFSSPortalAPI.V1.Gateways
             try
             {
                 var serviceTaxonomies = Context.ServiceTaxonomies
-                    .Where(x => x.TaxonomyId == taxonomyId);
+                    .Where(x => x.TaxonomyId == taxonomyId)
+                    .Include(x => x.Service);
                 return _mapper.ToDomain(serviceTaxonomies);
             }
             catch (Exception e)

--- a/LBHFSSPortalAPI/V1/UseCase/TaxonomyUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/TaxonomyUseCase.cs
@@ -37,6 +37,13 @@ namespace LBHFSSPortalAPI.V1.UseCase
 
         public void ExecuteDelete(int id)
         {
+            var gatewayResponse = _taxonomyGateway.GetServiceTaxonomies(id);
+            if (gatewayResponse.Count > 0)
+                throw new ServiceTaxonomyExistsException()
+                {
+                    DevErrorMessage = $"Provided taxonomy is still linked to services. Ensure there are no services linked to taxonomy {id}",
+                    Services = gatewayResponse.ToDictionary(x => (int) x.ServiceId, y => y.Service.Name)
+                };
             LambdaLogger.Log($"Delete taxonomy {id}");
             _taxonomyGateway.DeleteTaxonomy(id);
         }

--- a/LBHFSSPortalAPI/V1/UseCase/TaxonomyUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/TaxonomyUseCase.cs
@@ -42,8 +42,9 @@ namespace LBHFSSPortalAPI.V1.UseCase
                 throw new ServiceTaxonomyExistsException()
                 {
                     DevErrorMessage = $"Provided taxonomy is still linked to services. Ensure there are no services linked to taxonomy {id}",
-                    Services = gatewayResponse.ToDictionary(x => (int) x.ServiceId, y => y.Service.Name)
+                    Services = gatewayResponse.Select(x => new ServiceError { Id = (int) x.ServiceId, ServiceName = x.Service.Name }).ToList()
                 };
+
             LambdaLogger.Log($"Delete taxonomy {id}");
             _taxonomyGateway.DeleteTaxonomy(id);
         }


### PR DESCRIPTION
What### 

- Added some validation to the delete taxonomy endpoint to prevent taxonomies being deleted when they are linked to a service.
- Added a custom response so the service Ids and names are returned as well as the 400 response when an attempt to delete an active taxonomy occurs.

Why### 
Active taxonomy items (ones linked to services) should not be able to be deleted.

Not 100% happy with how I've implemented the custom response - ran into issues with trying to pass the existing exception object to BadResponse() so found this was the only way I could get it working.