### PR TITLE
Deleting users update

### DIFF
--- a/LBHFSSPortalAPI/V1/Gateways/Interfaces/IUsersGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/Interfaces/IUsersGateway.cs
@@ -21,5 +21,6 @@ namespace LBHFSSPortalAPI.V1.Gateways.Interfaces
         UserDomain SetDefaultRole(UserDomain user);
         List<string> GetUserRoleList(int userId);
         void SetUserStatus(UserDomain user, string status);
+        void ClearUserRoles(int userId);
     }
 }

--- a/LBHFSSPortalAPI/V1/Gateways/UsersGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/UsersGateway.cs
@@ -426,7 +426,7 @@ namespace LBHFSSPortalAPI.V1.Gateways
             }
         }
 
-        private void ClearUserRoles(int userId)
+        public void ClearUserRoles(int userId)
         {
             try
             {

--- a/LBHFSSPortalAPI/V1/UseCase/DeleteUserRequestUseCase.cs
+++ b/LBHFSSPortalAPI/V1/UseCase/DeleteUserRequestUseCase.cs
@@ -9,14 +9,17 @@ namespace LBHFSSPortalAPI.V1.UseCase
     {
         private readonly IUsersGateway _usersGateway;
         private readonly ISessionsGateway _sessionsGateway;
+        private readonly IUserOrganisationGateway _userOrganisationGateway;
         private readonly IAuthenticateGateway _authenticateGateway;
 
         public DeleteUserRequestUseCase(IUsersGateway usersGateway,
                                         ISessionsGateway sessionsGateway,
+                                        IUserOrganisationGateway userOrganisationGateway,
                                         IAuthenticateGateway authenticateGateway)
         {
             _usersGateway = usersGateway;
             _sessionsGateway = sessionsGateway;
+            _userOrganisationGateway = userOrganisationGateway;
             _authenticateGateway = authenticateGateway;
         }
 
@@ -30,6 +33,8 @@ namespace LBHFSSPortalAPI.V1.UseCase
             if (_authenticateGateway.DeleteUser(user.Email))
             {
                 _sessionsGateway.RemoveSessions(user.Id);
+                _userOrganisationGateway.DeleteUserOrganisationLink(user.Id);
+                _usersGateway.ClearUserRoles(user.Id);
                 _usersGateway.SetUserStatus(user, UserStatus.Deleted);
             }
         }


### PR DESCRIPTION
# What
- Delete user_role and user_organisation records when a user is set as deleted.

# Why
- When a user record is set as deleted any associations to that user should be removed or linking to that user from another area will result in an error