### PR TITLE
Circle-CI hotfix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,10 +209,17 @@ workflows:
           filters:
             branches:
               only: master
+      - permit-production-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+          filters:
+            branches:
+              only: master
       - assume-role-production:
           context: api-assume-role-production-context
           requires:
-            - deploy-to-staging
+            - permit-production-release
           filters:
             branches:
               only: master
@@ -222,16 +229,8 @@ workflows:
           filters:
             branches:
               only: master
-      - permit-production-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-          filters:
-            branches:
-              only: master
       - deploy-to-production:
           requires:
-            - permit-production-release
             - assume-role-production
           filters:
             branches:


### PR DESCRIPTION
# What
- Fixed order of production deployment steps so assuming the production role and deployment to production both happen after permission is granted to deploy so context remains fresh.
# Why
- Currently the assume-role-production step is happening independently of the permit-deploy-production step.  It means that in some cases where the permit production step doesn't happen right away the established context in the assume role step expires, causing the production deployment to fail.  This fix correctly orders the steps so that the assume role step runs after the permit production step runs. 