### PR TITLE
Filter out deleted users

### DIFF
--- a/LBHFSSPortalAPI.Tests/DatabaseTests.cs
+++ b/LBHFSSPortalAPI.Tests/DatabaseTests.cs
@@ -28,6 +28,12 @@ namespace LBHFSSPortalAPI.Tests
         {
             _transaction.Rollback();
             _transaction.Dispose();
+            ClearDb();
+        }
+
+        private void ClearDb()
+        {
+            DatabaseContext.Database.ExecuteSqlRaw("TRUNCATE TABLE users CASCADE");
         }
     }
 }

--- a/LBHFSSPortalAPI.Tests/TestHelpers/EntityHelpers.cs
+++ b/LBHFSSPortalAPI.Tests/TestHelpers/EntityHelpers.cs
@@ -25,7 +25,21 @@ namespace LBHFSSPortalAPI.Tests.TestHelpers
 
         public static User CreateUser()
         {
-            return Randomm.Build<User>().Without(u => u.Id).Create();
+            return Randomm.Build<User>()
+                .Without(u => u.Id)
+                .Without(u => u.UserOrganisations)
+                .Without(u => u.UserRoles)
+                .Create();
+        }
+
+        public static List<User> CreateUsers(int count = 5)
+        {
+            var users = new List<User>();
+            for (var a = 0; a < count; a++)
+            {
+                users.Add(CreateUser());
+            }
+            return users;
         }
 
         public static File CreateFile()

--- a/LBHFSSPortalAPI.Tests/V1/Gateways/UsersGatewayTests.cs
+++ b/LBHFSSPortalAPI.Tests/V1/Gateways/UsersGatewayTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using LBHFSSPortalAPI.Tests.TestHelpers;
+using LBHFSSPortalAPI.V1.Boundary.Requests;
+using LBHFSSPortalAPI.V1.Gateways;
+using NUnit.Framework;
+
+namespace LBHFSSPortalAPI.Tests.V1.Gateways
+{
+    [TestFixture]
+    public class UsersGatewayTests : DatabaseTests
+    {
+        private UsersGateway _classUnderTest;
+
+        [SetUp]
+        public void Setup()
+        {
+            _classUnderTest = new UsersGateway(DatabaseContext);
+        }
+
+        [TestCase(TestName = "Given list of users in the database users are returned")]
+        public async Task GivenUsersInDatabaseUsersGetsReturned()
+        {
+            var count = 5;
+            var users = EntityHelpers.CreateUsers(count);
+            var queryParams = new UserQueryParam
+            {
+                Sort = "name",
+                Direction = "asc"
+            };
+            await DatabaseContext.Users.AddRangeAsync(users).ConfigureAwait(true);
+            await DatabaseContext.SaveChangesAsync().ConfigureAwait(true);
+            var gatewayResult = await _classUnderTest.GetAllUsers(queryParams).ConfigureAwait(true);
+            gatewayResult.Should().NotBeNull();
+            gatewayResult.Count.Should().Be(count);
+        }
+
+        [TestCase(TestName = "Given list of users in the database users with status of deleted are not returned")]
+        public async Task GivenUsersInDatabaseUsersWithStatusOfDeletedDoNotGetReturned()
+        {
+            var count = 5;
+            var users = EntityHelpers.CreateUsers(count);
+            users.First().Status = "deleted";
+            var queryParams = new UserQueryParam
+            {
+                Sort = "name",
+                Direction = "asc"
+            };
+            await DatabaseContext.Users.AddRangeAsync(users).ConfigureAwait(true);
+            await DatabaseContext.SaveChangesAsync().ConfigureAwait(true);
+            var gatewayResult = await _classUnderTest.GetAllUsers(queryParams).ConfigureAwait(true);
+            gatewayResult.Should().NotBeNull();
+            gatewayResult.Count.Should().Be(count - 1);
+        }
+
+    }
+}

--- a/LBHFSSPortalAPI/V1/Gateways/UsersGateway.cs
+++ b/LBHFSSPortalAPI/V1/Gateways/UsersGateway.cs
@@ -41,7 +41,8 @@ namespace LBHFSSPortalAPI.V1.Gateways
                     UserErrorMessage = "The sort direction was not valid (must be one of asc, desc)"
                 };
 
-            var matchingUsers = Context.Users.AsQueryable();
+            var matchingUsers = Context.Users.AsQueryable()
+                .Where(u => u.Status.ToLower() != "deleted");
 
             // handle search
             if (!string.IsNullOrWhiteSpace(userQueryParam.Search))
@@ -91,7 +92,6 @@ namespace LBHFSSPortalAPI.V1.Gateways
                     DevErrorMessage = e.Message
                 };
             }
-
             return response;
         }
 


### PR DESCRIPTION
# What
- Updated users gateway to return only users who have not been marked as deleted

# Why
- An error occurs when attempting to load the record of a users who is deleted.  These users should not be returned.

# Link to ticket
- https://app.clickup.com/t/d2x1na